### PR TITLE
PyO3 backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license-file = "LICENSE"
 
 [dependencies]
 libc = "0.2"
-cpython = "0.1"
-python3-sys = "0.1"
 num-complex = "0.1"
 ndarray = "0.10"
+pyo3 = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,8 @@ license-file = "LICENSE"
 libc = "0.2"
 num-complex = "0.1"
 ndarray = "0.10"
-pyo3 = "0.2"
+
+[dependencies.pyo3]
+git = "http://github.com/termoshtt/pyo3"
+branch = "pyobject_macros"
+version = "0.2"

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -9,5 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-cpython = "0.1"
 ndarray = "0.10"
+
+[dependencies.pyo3]
+version = "*"
+features = ["extension-module"]

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -1,12 +1,12 @@
 
 #[macro_use]
-extern crate cpython;
+extern crate pyo3;
 extern crate numpy;
 extern crate ndarray;
 
 use numpy::*;
 use ndarray::*;
-use cpython::{PyResult, Python, PyObject};
+use pyo3::{PyResult, Python, PyObject};
 
 /* Pure rust-ndarray functions */
 
@@ -20,7 +20,7 @@ fn mult(a: f64, mut x: ArrayViewMutD<f64>) {
     x *= a;
 }
 
-/* rust-cpython wrappers (to be exposed) */
+/* rust-pyo3 wrappers (to be exposed) */
 
 // wrapper of `axpy`
 fn axpy_py(py: Python, a: f64, x: PyArray, y: PyArray) -> PyResult<PyArray> {

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -1,48 +1,41 @@
+#![feature(proc_macro, proc_macro_path_invoc, specialization)]
 
-#[macro_use]
-extern crate pyo3;
-extern crate numpy;
 extern crate ndarray;
+extern crate numpy;
+extern crate pyo3;
 
-use numpy::*;
 use ndarray::*;
-use pyo3::{PyResult, Python, PyObject};
+use numpy::*;
+use pyo3::{py, PyModule, PyObject, PyResult, Python};
 
-/* Pure rust-ndarray functions */
+#[py::modinit(rust_ext)]
+fn init_module(py: Python, m: &PyModule) -> PyResult<()> {
+    // immutable example
+    fn axpy(a: f64, x: ArrayViewD<f64>, y: ArrayViewD<f64>) -> ArrayD<f64> {
+        a * &x + &y
+    }
 
-// immutable example
-fn axpy(a: f64, x: ArrayViewD<f64>, y: ArrayViewD<f64>) -> ArrayD<f64> {
-    a * &x + &y
-}
+    // mutable example (no return)
+    fn mult(a: f64, mut x: ArrayViewMutD<f64>) {
+        x *= a;
+    }
 
-// mutable example (no return)
-fn mult(a: f64, mut x: ArrayViewMutD<f64>) {
-    x *= a;
-}
+    // wrapper of `axpy`
+    #[pyfn(m, "axpy")]
+    fn axpy_py(py: Python, a: f64, x: PyArray, y: PyArray) -> PyResult<PyArray> {
+        let np = PyArrayModule::import(py)?;
+        let x = x.as_array().into_pyresult(py, "x must be f64 array")?;
+        let y = y.as_array().into_pyresult(py, "y must be f64 array")?;
+        Ok(axpy(a, x, y).into_pyarray(py, &np))
+    }
 
-/* rust-pyo3 wrappers (to be exposed) */
+    // wrapper of `mult`
+    #[pyfn(m, "mult")]
+    fn mult_py(py: Python, a: f64, x: PyArray) -> PyResult<PyObject> {
+        let x = x.as_array_mut().into_pyresult(py, "x must be f64 array")?;
+        mult(a, x);
+        Ok(py.None()) // Python function must returns
+    }
 
-// wrapper of `axpy`
-fn axpy_py(py: Python, a: f64, x: PyArray, y: PyArray) -> PyResult<PyArray> {
-    let np = PyArrayModule::import(py)?;
-    let x = x.as_array().into_pyresult(py, "x must be f64 array")?;
-    let y = y.as_array().into_pyresult(py, "y must be f64 array")?;
-    Ok(axpy(a, x, y).into_pyarray(py, &np))
-}
-
-// wrapper of `mult`
-fn mult_py(py: Python, a: f64, x: PyArray) -> PyResult<PyObject> {
-    let x = x.as_array_mut().into_pyresult(py, "x must be f64 array")?;
-    mult(a, x);
-    Ok(py.None()) // Python function must returns
-}
-
-/* Define module "_rust_ext" */
-py_module_initializer!(_rust_ext, init_rust_ext, PyInit__rust_ext, |py, m| {
-    m.add(py, "__doc__", "Rust extension for NumPy")?;
-    m.add(py,
-             "axpy",
-             py_fn!(py, axpy_py(a: f64, x: PyArray, y: PyArray)))?;
-    m.add(py, "mult", py_fn!(py, mult_py(a: f64, x: PyArray)))?;
     Ok(())
-});
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,9 +1,9 @@
 //! Untyped safe interface for NumPy ndarray
 
-use cpython::*;
 use ndarray::*;
 use npyffi;
-use pyffi;
+use pyo3::ffi;
+use pyo3::*;
 
 use std::os::raw::c_void;
 use std::ptr::null_mut;
@@ -23,12 +23,12 @@ impl PyArray {
         self.0.steal_ptr() as *mut npyffi::PyArrayObject
     }
 
-    pub unsafe fn from_owned_ptr(py: Python, ptr: *mut pyffi::PyObject) -> Self {
+    pub unsafe fn from_owned_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> Self {
         let obj = PyObject::from_owned_ptr(py, ptr);
         PyArray(obj)
     }
 
-    pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyffi::PyObject) -> Self {
+    pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> Self {
         let obj = PyObject::from_borrowed_ptr(py, ptr);
         PyArray(obj)
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,11 +14,7 @@ use super::*;
 /// Untyped safe interface for NumPy ndarray.
 pub struct PyArray(PyObject);
 
-impl ToPyPointer for PyArray {
-    fn as_ptr(&self) -> *mut ffi::PyObject {
-        self.0.as_ptr()
-    }
-}
+pyobject_native_type!(PyArray, npyffi::PyArray_Type, npyffi::PyArray_Check);
 
 impl PyArray {
     pub fn as_array_ptr(&self) -> *mut npyffi::PyArrayObject {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,5 +1,5 @@
-use cpython::Python;
 use ndarray::*;
+use pyo3::Python;
 
 use std::iter::Iterator;
 use std::mem::size_of;

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,11 +1,10 @@
-
 use cpython::Python;
 use ndarray::*;
 
-use std::os::raw::c_void;
-use std::ptr::null_mut;
 use std::iter::Iterator;
 use std::mem::size_of;
+use std::os::raw::c_void;
+use std::ptr::null_mut;
 
 use super::*;
 
@@ -44,7 +43,8 @@ pub trait ToPyArray {
 }
 
 impl<Iter, T: TypeNum> ToPyArray for Iter
-    where Iter: Iterator<Item = T> + Sized
+where
+    Iter: Iterator<Item = T> + Sized,
 {
     fn to_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray {
         let vec: Vec<T> = self.collect();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 //! Define Errors
 
+use cpython::*;
 use std::error;
 use std::fmt;
-use cpython::*;
 
 pub trait IntoPyErr {
     fn into_pyerr(self, py: Python, msg: &str) -> PyErr;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,18 +5,18 @@ use std::error;
 use std::fmt;
 
 pub trait IntoPyErr {
-    fn into_pyerr(self, py: Python, msg: &str) -> PyErr;
+    fn into_pyerr(self, msg: &str) -> PyErr;
 }
 
 pub trait IntoPyResult {
     type ValueType;
-    fn into_pyresult(self, py: Python, message: &str) -> PyResult<Self::ValueType>;
+    fn into_pyresult(self, msg: &str) -> PyResult<Self::ValueType>;
 }
 
 impl<T, E: IntoPyErr> IntoPyResult for Result<T, E> {
     type ValueType = T;
-    fn into_pyresult(self, py: Python, msg: &str) -> PyResult<T> {
-        self.map_err(|e| e.into_pyerr(py, msg))
+    fn into_pyresult(self, msg: &str) -> PyResult<T> {
+        self.map_err(|e| e.into_pyerr(msg))
     }
 }
 
@@ -49,8 +49,8 @@ impl error::Error for ArrayCastError {
 }
 
 impl IntoPyErr for ArrayCastError {
-    fn into_pyerr(self, py: Python, msg: &str) -> PyErr {
+    fn into_pyerr(self, msg: &str) -> PyErr {
         let msg = format!("rust_numpy::ArrayCastError: {}", msg);
-        PyErr::new::<exc::TypeError, _>(py, msg)
+        PyErr::new::<exc::TypeError, _>(msg)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Define Errors
 
-use cpython::*;
+use pyo3::*;
 use std::error;
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
-extern crate cpython;
 extern crate libc;
 extern crate ndarray;
 extern crate num_complex;
-extern crate python3_sys as pyffi;
+extern crate pyo3;
 
 pub mod array;
 pub mod convert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,17 @@
-
-extern crate python3_sys as pyffi;
 extern crate cpython;
 extern crate libc;
-extern crate num_complex;
 extern crate ndarray;
+extern crate num_complex;
+extern crate python3_sys as pyffi;
 
-pub mod types;
 pub mod array;
-pub mod npyffi;
-pub mod error;
 pub mod convert;
+pub mod error;
+pub mod npyffi;
+pub mod types;
 
 pub use array::PyArray;
-pub use types::*;
-pub use error::*;
 pub use convert::{IntoPyArray, ToPyArray};
+pub use error::*;
 pub use npyffi::{PyArrayModule, PyUFuncModule};
+pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
+#![feature(specialization)]
+
 extern crate libc;
 extern crate ndarray;
 extern crate num_complex;
+#[macro_use]
 extern crate pyo3;
 
 pub mod array;

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -7,9 +7,9 @@ use std::ops::Deref;
 use std::os::raw::*;
 use std::ptr::null_mut;
 
-use cpython::{ObjectProtocol, PyModule, PyResult, Python, PythonObject};
-use pyffi;
-use pyffi::{PyObject, PyTypeObject};
+use pyo3::ffi;
+use pyo3::ffi::{PyObject, PyTypeObject};
+use pyo3::{ObjectProtocol, PyModule, PyResult, Python};
 
 use npyffi::*;
 
@@ -48,7 +48,7 @@ impl PyArrayModule {
         let numpy = py.import("numpy.core.multiarray")?;
         let c_api = numpy.as_object().getattr(py, "_ARRAY_API")?;
         let api = unsafe {
-            pyffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut())
+            pyo3::ffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut())
                 as *const *const c_void
         };
         Ok(Self {
@@ -375,10 +375,10 @@ impl_array_type!(
 
 #[allow(non_snake_case)]
 pub unsafe fn PyArray_Check(np: &PyArrayModule, op: *mut PyObject) -> c_int {
-    pyffi::PyObject_TypeCheck(op, np.get_type_object(ArrayType::PyArray_Type))
+    pyo3::ffi::PyObject_TypeCheck(op, np.get_type_object(ArrayType::PyArray_Type))
 }
 
 #[allow(non_snake_case)]
 pub unsafe fn PyArray_CheckExact(np: &PyArrayModule, op: *mut PyObject) -> c_int {
-    (pyffi::Py_TYPE(op) == np.get_type_object(ArrayType::PyArray_Type)) as c_int
+    (pyo3::ffi::Py_TYPE(op) == np.get_type_object(ArrayType::PyArray_Type)) as c_int
 }

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -2,14 +2,14 @@
 //!
 //! https://docs.scipy.org/doc/numpy/reference/c-api.array.html
 
-use std::os::raw::*;
-use std::ptr::null_mut;
 use libc::FILE;
 use std::ops::Deref;
+use std::os::raw::*;
+use std::ptr::null_mut;
 
+use cpython::{ObjectProtocol, PyModule, PyResult, Python, PythonObject};
 use pyffi;
 use pyffi::{PyObject, PyTypeObject};
-use cpython::{Python, PythonObject, ObjectProtocol, PyResult, PyModule};
 
 use npyffi::*;
 
@@ -48,8 +48,8 @@ impl PyArrayModule {
         let numpy = py.import("numpy.core.multiarray")?;
         let c_api = numpy.as_object().getattr(py, "_ARRAY_API")?;
         let api = unsafe {
-            pyffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut()) as
-            *const *const c_void
+            pyffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut())
+                as *const *const c_void
         };
         Ok(Self {
             numpy: numpy,
@@ -331,45 +331,47 @@ impl PyArrayModule {
 }
 }} // impl_array_type!;
 
-impl_array_type!((1, PyBigArray_Type),
-                 (2, PyArray_Type),
-                 (3, PyArrayDescr_Type),
-                 (4, PyArrayFlags_Type),
-                 (5, PyArrayIter_Type),
-                 (6, PyArrayMultiIter_Type),
-                 (7, NPY_NUMUSERTYPES),
-                 (8, PyBoolArrType_Type),
-                 (9, _PyArrayScalar_BoolValues),
-                 (10, PyGenericArrType_Type),
-                 (11, PyNumberArrType_Type),
-                 (12, PyIntegerArrType_Type),
-                 (13, PySignedIntegerArrType_Type),
-                 (14, PyUnsignedIntegerArrType_Type),
-                 (15, PyInexactArrType_Type),
-                 (16, PyFloatingArrType_Type),
-                 (17, PyComplexFloatingArrType_Type),
-                 (18, PyFlexibleArrType_Type),
-                 (19, PyCharacterArrType_Type),
-                 (20, PyByteArrType_Type),
-                 (21, PyShortArrType_Type),
-                 (22, PyIntArrType_Type),
-                 (23, PyLongArrType_Type),
-                 (24, PyLongLongArrType_Type),
-                 (25, PyUByteArrType_Type),
-                 (26, PyUShortArrType_Type),
-                 (27, PyUIntArrType_Type),
-                 (28, PyULongArrType_Type),
-                 (29, PyULongLongArrType_Type),
-                 (30, PyFloatArrType_Type),
-                 (31, PyDoubleArrType_Type),
-                 (32, PyLongDoubleArrType_Type),
-                 (33, PyCFloatArrType_Type),
-                 (34, PyCDoubleArrType_Type),
-                 (35, PyCLongDoubleArrType_Type),
-                 (36, PyObjectArrType_Type),
-                 (37, PyStringArrType_Type),
-                 (38, PyUnicodeArrType_Type),
-                 (39, PyVoidArrType_Type));
+impl_array_type!(
+    (1, PyBigArray_Type),
+    (2, PyArray_Type),
+    (3, PyArrayDescr_Type),
+    (4, PyArrayFlags_Type),
+    (5, PyArrayIter_Type),
+    (6, PyArrayMultiIter_Type),
+    (7, NPY_NUMUSERTYPES),
+    (8, PyBoolArrType_Type),
+    (9, _PyArrayScalar_BoolValues),
+    (10, PyGenericArrType_Type),
+    (11, PyNumberArrType_Type),
+    (12, PyIntegerArrType_Type),
+    (13, PySignedIntegerArrType_Type),
+    (14, PyUnsignedIntegerArrType_Type),
+    (15, PyInexactArrType_Type),
+    (16, PyFloatingArrType_Type),
+    (17, PyComplexFloatingArrType_Type),
+    (18, PyFlexibleArrType_Type),
+    (19, PyCharacterArrType_Type),
+    (20, PyByteArrType_Type),
+    (21, PyShortArrType_Type),
+    (22, PyIntArrType_Type),
+    (23, PyLongArrType_Type),
+    (24, PyLongLongArrType_Type),
+    (25, PyUByteArrType_Type),
+    (26, PyUShortArrType_Type),
+    (27, PyUIntArrType_Type),
+    (28, PyULongArrType_Type),
+    (29, PyULongLongArrType_Type),
+    (30, PyFloatArrType_Type),
+    (31, PyDoubleArrType_Type),
+    (32, PyLongDoubleArrType_Type),
+    (33, PyCFloatArrType_Type),
+    (34, PyCDoubleArrType_Type),
+    (35, PyCLongDoubleArrType_Type),
+    (36, PyObjectArrType_Type),
+    (37, PyStringArrType_Type),
+    (38, PyUnicodeArrType_Type),
+    (39, PyVoidArrType_Type)
+);
 
 #[allow(non_snake_case)]
 pub unsafe fn PyArray_Check(np: &PyArrayModule, op: *mut PyObject) -> c_int {

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -9,12 +9,12 @@
 //! - http://docs.python.jp/3/c-api/
 //! - http://dgrunwald.github.io/rust-cpython/doc/cpython/
 
-pub mod types;
-pub mod objects;
 pub mod array;
+pub mod objects;
+pub mod types;
 pub mod ufunc;
 
-pub use self::types::*;
-pub use self::objects::*;
 pub use self::array::*;
+pub use self::objects::*;
+pub use self::types::*;
 pub use self::ufunc::*;

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -7,7 +7,7 @@
 //! basic usage of Python C API, especially for the reference counting.
 //!
 //! - http://docs.python.jp/3/c-api/
-//! - http://dgrunwald.github.io/rust-cpython/doc/cpython/
+//! - http://dgrunwald.github.io/rust-pyo3/doc/pyo3/
 
 pub mod array;
 pub mod objects;

--- a/src/npyffi/objects.rs
+++ b/src/npyffi/objects.rs
@@ -4,7 +4,7 @@
 #![allow(non_camel_case_types, non_snake_case)]
 
 use libc::FILE;
-use pyffi::*;
+use pyo3::ffi::*;
 use std::option::Option;
 use std::os::raw::*;
 

--- a/src/npyffi/objects.rs
+++ b/src/npyffi/objects.rs
@@ -5,8 +5,8 @@
 
 use libc::FILE;
 use pyffi::*;
-use std::os::raw::*;
 use std::option::Option;
+use std::os::raw::*;
 
 use super::types::*;
 
@@ -80,102 +80,92 @@ pub struct PyArray_ArrFuncs {
     pub argmin: PyArray_ArgFunc,
 }
 
-pub type PyArray_GetItemFunc = Option<unsafe extern "C" fn(*mut c_void, *mut c_void)
-                                                           -> *mut PyObject>;
-pub type PyArray_SetItemFunc = Option<unsafe extern "C" fn(*mut PyObject,
-                                                           *mut c_void,
-                                                           *mut c_void)
-                                                           -> c_int>;
-pub type PyArray_CopySwapNFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                             npy_intp,
-                                                             *mut c_void,
-                                                             npy_intp,
-                                                             npy_intp,
-                                                             c_int,
-                                                             *mut c_void)>;
-pub type PyArray_CopySwapFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                            *mut c_void,
-                                                            c_int,
-                                                            *mut c_void)>;
+pub type PyArray_GetItemFunc =
+    Option<unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut PyObject>;
+pub type PyArray_SetItemFunc =
+    Option<unsafe extern "C" fn(*mut PyObject, *mut c_void, *mut c_void) -> c_int>;
+pub type PyArray_CopySwapNFunc = Option<
+    unsafe extern "C" fn(
+        *mut c_void,
+        npy_intp,
+        *mut c_void,
+        npy_intp,
+        npy_intp,
+        c_int,
+        *mut c_void,
+    ),
+>;
+pub type PyArray_CopySwapFunc =
+    Option<unsafe extern "C" fn(*mut c_void, *mut c_void, c_int, *mut c_void)>;
 pub type PyArray_NonzeroFunc = Option<unsafe extern "C" fn(*mut c_void, *mut c_void) -> c_uchar>;
-pub type PyArray_CompareFunc = Option<unsafe extern "C" fn(*const c_void,
-                                                           *const c_void,
-                                                           *mut c_void)
-                                                           -> c_int>;
-pub type PyArray_ArgFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                       npy_intp,
-                                                       *mut npy_intp,
-                                                       *mut c_void)
-                                                       -> c_int>;
-pub type PyArray_DotFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                       npy_intp,
-                                                       *mut c_void,
-                                                       npy_intp,
-                                                       *mut c_void,
-                                                       npy_intp,
-                                                       *mut c_void)>;
-pub type PyArray_VectorUnaryFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                               *mut c_void,
-                                                               npy_intp,
-                                                               *mut c_void,
-                                                               *mut c_void)>;
-pub type PyArray_ScanFunc = Option<unsafe extern "C" fn(*mut FILE,
-                                                        *mut c_void,
-                                                        *mut c_char,
-                                                        *mut PyArray_Descr)
-                                                        -> c_int>;
-pub type PyArray_FromStrFunc = Option<unsafe extern "C" fn(*mut c_char,
-                                                           *mut c_void,
-                                                           *mut *mut c_char,
-                                                           *mut PyArray_Descr)
-                                                           -> c_int>;
-pub type PyArray_FillFunc = Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut c_void) -> c_int>;
-pub type PyArray_SortFunc = Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut c_void) -> c_int>;
-pub type PyArray_ArgSortFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                           *mut npy_intp,
-                                                           npy_intp,
-                                                           *mut c_void)
-                                                           -> c_int>;
-pub type PyArray_PartitionFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                             npy_intp,
-                                                             npy_intp,
-                                                             *mut npy_intp,
-                                                             *mut npy_intp,
-                                                             *mut c_void)
-                                                             -> c_int>;
-pub type PyArray_ArgPartitionFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                                *mut npy_intp,
-                                                                npy_intp,
-                                                                npy_intp,
-                                                                *mut npy_intp,
-                                                                *mut npy_intp,
-                                                                *mut c_void)
-                                                                -> c_int>;
-pub type PyArray_FillWithScalarFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                                  npy_intp,
-                                                                  *mut c_void,
-                                                                  *mut c_void)
-                                                                  -> c_int>;
+pub type PyArray_CompareFunc =
+    Option<unsafe extern "C" fn(*const c_void, *const c_void, *mut c_void) -> c_int>;
+pub type PyArray_ArgFunc =
+    Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut npy_intp, *mut c_void) -> c_int>;
+pub type PyArray_DotFunc = Option<
+    unsafe extern "C" fn(
+        *mut c_void,
+        npy_intp,
+        *mut c_void,
+        npy_intp,
+        *mut c_void,
+        npy_intp,
+        *mut c_void,
+    ),
+>;
+pub type PyArray_VectorUnaryFunc =
+    Option<unsafe extern "C" fn(*mut c_void, *mut c_void, npy_intp, *mut c_void, *mut c_void)>;
+pub type PyArray_ScanFunc =
+    Option<unsafe extern "C" fn(*mut FILE, *mut c_void, *mut c_char, *mut PyArray_Descr) -> c_int>;
+pub type PyArray_FromStrFunc = Option<
+    unsafe extern "C" fn(*mut c_char, *mut c_void, *mut *mut c_char, *mut PyArray_Descr) -> c_int,
+>;
+pub type PyArray_FillFunc =
+    Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut c_void) -> c_int>;
+pub type PyArray_SortFunc =
+    Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut c_void) -> c_int>;
+pub type PyArray_ArgSortFunc =
+    Option<unsafe extern "C" fn(*mut c_void, *mut npy_intp, npy_intp, *mut c_void) -> c_int>;
+pub type PyArray_PartitionFunc = Option<
+    unsafe extern "C" fn(
+        *mut c_void,
+        npy_intp,
+        npy_intp,
+        *mut npy_intp,
+        *mut npy_intp,
+        *mut c_void,
+    ) -> c_int,
+>;
+pub type PyArray_ArgPartitionFunc = Option<
+    unsafe extern "C" fn(
+        *mut c_void,
+        *mut npy_intp,
+        npy_intp,
+        npy_intp,
+        *mut npy_intp,
+        *mut npy_intp,
+        *mut c_void,
+    ) -> c_int,
+>;
+pub type PyArray_FillWithScalarFunc =
+    Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut c_void, *mut c_void) -> c_int>;
 pub type PyArray_ScalarKindFunc = Option<unsafe extern "C" fn(*mut c_void) -> c_int>;
-pub type PyArray_FastClipFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                            npy_intp,
-                                                            *mut c_void,
-                                                            *mut c_void,
-                                                            *mut c_void)>;
-pub type PyArray_FastPutmaskFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                               *mut c_void,
-                                                               npy_intp,
-                                                               *mut c_void,
-                                                               npy_intp)>;
-pub type PyArray_FastTakeFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                            *mut c_void,
-                                                            *mut npy_intp,
-                                                            npy_intp,
-                                                            npy_intp,
-                                                            npy_intp,
-                                                            npy_intp,
-                                                            NPY_CLIPMODE)
-                                                            -> c_int>;
+pub type PyArray_FastClipFunc =
+    Option<unsafe extern "C" fn(*mut c_void, npy_intp, *mut c_void, *mut c_void, *mut c_void)>;
+pub type PyArray_FastPutmaskFunc =
+    Option<unsafe extern "C" fn(*mut c_void, *mut c_void, npy_intp, *mut c_void, npy_intp)>;
+pub type PyArray_FastTakeFunc = Option<
+    unsafe extern "C" fn(
+        *mut c_void,
+        *mut c_void,
+        *mut npy_intp,
+        npy_intp,
+        npy_intp,
+        npy_intp,
+        npy_intp,
+        NPY_CLIPMODE,
+    ) -> c_int,
+>;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -248,39 +238,48 @@ pub struct PyUFuncObject {
     pub iter_flags: npy_uint32,
 }
 
-pub type PyUFuncGenericFunction = Option<unsafe extern "C" fn(*mut *mut c_char,
-                                                              *mut npy_intp,
-                                                              *mut npy_intp,
-                                                              *mut c_void)>;
-pub type PyUFunc_MaskedStridedInnerLoopFunc = Option<unsafe extern "C" fn(*mut *mut c_char,
-                                                                          *mut npy_intp,
-                                                                          *mut c_char,
-                                                                          npy_intp,
-                                                                          npy_intp,
-                                                                          *mut NpyAuxData)>;
-pub type PyUFunc_TypeResolutionFunc = Option<unsafe extern "C" fn(*mut PyUFuncObject,
-                                                                  NPY_CASTING,
-                                                                  *mut *mut PyArrayObject,
-                                                                  *mut PyObject,
-                                                                  *mut *mut PyArray_Descr)
-                                                                  -> c_int>;
-pub type PyUFunc_LegacyInnerLoopSelectionFunc =
-    Option<unsafe extern "C" fn(*mut PyUFuncObject,
-                                *mut *mut PyArray_Descr,
-                                *mut PyUFuncGenericFunction,
-                                *mut *mut c_void,
-                                *mut c_int)
-                                -> c_int>;
-pub type PyUFunc_MaskedInnerLoopSelectionFunc =
-    Option<unsafe extern "C" fn(*mut PyUFuncObject,
-                                *mut *mut PyArray_Descr,
-                                *mut PyArray_Descr,
-                                *mut npy_intp,
-                                npy_intp,
-                                *mut PyUFunc_MaskedStridedInnerLoopFunc,
-                                *mut *mut NpyAuxData,
-                                *mut c_int)
-                                -> c_int>;
+pub type PyUFuncGenericFunction =
+    Option<unsafe extern "C" fn(*mut *mut c_char, *mut npy_intp, *mut npy_intp, *mut c_void)>;
+pub type PyUFunc_MaskedStridedInnerLoopFunc = Option<
+    unsafe extern "C" fn(
+        *mut *mut c_char,
+        *mut npy_intp,
+        *mut c_char,
+        npy_intp,
+        npy_intp,
+        *mut NpyAuxData,
+    ),
+>;
+pub type PyUFunc_TypeResolutionFunc = Option<
+    unsafe extern "C" fn(
+        *mut PyUFuncObject,
+        NPY_CASTING,
+        *mut *mut PyArrayObject,
+        *mut PyObject,
+        *mut *mut PyArray_Descr,
+    ) -> c_int,
+>;
+pub type PyUFunc_LegacyInnerLoopSelectionFunc = Option<
+    unsafe extern "C" fn(
+        *mut PyUFuncObject,
+        *mut *mut PyArray_Descr,
+        *mut PyUFuncGenericFunction,
+        *mut *mut c_void,
+        *mut c_int,
+    ) -> c_int,
+>;
+pub type PyUFunc_MaskedInnerLoopSelectionFunc = Option<
+    unsafe extern "C" fn(
+        *mut PyUFuncObject,
+        *mut *mut PyArray_Descr,
+        *mut PyArray_Descr,
+        *mut npy_intp,
+        npy_intp,
+        *mut PyUFunc_MaskedStridedInnerLoopFunc,
+        *mut *mut NpyAuxData,
+        *mut c_int,
+    ) -> c_int,
+>;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -385,13 +384,10 @@ pub struct PyArrayMapIterObject {
 
 pub type NpyIter_IterNextFunc = Option<unsafe extern "C" fn(*mut NpyIter) -> c_int>;
 pub type NpyIter_GetMultiIndexFunc = Option<unsafe extern "C" fn(*mut NpyIter, *mut npy_intp)>;
-pub type PyDataMem_EventHookFunc = Option<unsafe extern "C" fn(*mut c_void,
-                                                               *mut c_void,
-                                                               usize,
-                                                               *mut c_void)>;
-pub type npy_iter_get_dataptr_t = Option<unsafe extern "C" fn(*mut PyArrayIterObject,
-                                                              *mut npy_intp)
-                                                              -> *mut c_char>;
+pub type PyDataMem_EventHookFunc =
+    Option<unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *mut c_void)>;
+pub type npy_iter_get_dataptr_t =
+    Option<unsafe extern "C" fn(*mut PyArrayIterObject, *mut npy_intp) -> *mut c_char>;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use pyffi::{Py_hash_t, Py_intptr_t, Py_uintptr_t};
+use pyo3::ffi::{Py_hash_t, Py_intptr_t, Py_uintptr_t};
 use std::os::raw::*;
 
 pub type npy_intp = Py_intptr_t;

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use pyffi::{Py_intptr_t, Py_uintptr_t, Py_hash_t};
+use pyffi::{Py_hash_t, Py_intptr_t, Py_uintptr_t};
 use std::os::raw::*;
 
 pub type npy_intp = Py_intptr_t;

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -6,9 +6,9 @@ use std::ops::Deref;
 use std::os::raw::*;
 use std::ptr::null_mut;
 
-use cpython::{ObjectProtocol, PyModule, PyResult, Python, PythonObject};
-use pyffi;
-use pyffi::{PyObject, PyTypeObject};
+use pyo3::ffi;
+use pyo3::ffi::{PyObject, PyTypeObject};
+use pyo3::{ObjectProtocol, PyModule, PyResult, Python};
 
 use super::objects::*;
 use super::types::*;
@@ -45,7 +45,7 @@ impl PyUFuncModule {
         let numpy = py.import("numpy.core.umath")?;
         let c_api = numpy.as_object().getattr(py, "_UFUNC_API")?;
         let api = unsafe {
-            pyffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut())
+            pyo3::ffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut())
                 as *const *const c_void
         };
         Ok(Self {

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -2,16 +2,16 @@
 //!
 //! https://docs.scipy.org/doc/numpy/reference/c-api.ufunc.html
 
+use std::ops::Deref;
 use std::os::raw::*;
 use std::ptr::null_mut;
-use std::ops::Deref;
 
+use cpython::{ObjectProtocol, PyModule, PyResult, Python, PythonObject};
 use pyffi;
 use pyffi::{PyObject, PyTypeObject};
-use cpython::{Python, PythonObject, ObjectProtocol, PyResult, PyModule};
 
-use super::types::*;
 use super::objects::*;
+use super::types::*;
 
 /// Low-Level binding for UFunc API
 /// https://docs.scipy.org/doc/numpy/reference/c-api.ufunc.html
@@ -45,8 +45,8 @@ impl PyUFuncModule {
         let numpy = py.import("numpy.core.umath")?;
         let c_api = numpy.as_object().getattr(py, "_UFUNC_API")?;
         let api = unsafe {
-            pyffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut()) as
-            *const *const c_void
+            pyffi::PyCapsule_GetPointer(c_api.as_object().as_ptr(), null_mut())
+                as *const *const c_void
         };
         Ok(Self {
             numpy: numpy,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,9 @@
-
 pub use num_complex::Complex32 as c32;
 pub use num_complex::Complex64 as c64;
 
+pub use super::npyffi::npy_intp;
 pub use super::npyffi::NPY_ORDER;
 pub use super::npyffi::NPY_ORDER::{NPY_CORDER, NPY_FORTRANORDER};
-pub use super::npyffi::npy_intp;
 
 use super::npyffi::NPY_TYPES;
 
@@ -17,12 +16,13 @@ pub trait TypeNum {
 
 macro_rules! impl_type_num {
     ($t:ty, $npy_t:ident) => {
-impl TypeNum for $t {
-    fn typenum_enum() -> NPY_TYPES {
-        NPY_TYPES::$npy_t
-    }
-}
-}} // impl_type_num!
+        impl TypeNum for $t {
+            fn typenum_enum() -> NPY_TYPES {
+                NPY_TYPES::$npy_t
+            }
+        }
+    };
+} // impl_type_num!
 
 impl_type_num!(bool, NPY_BOOL);
 impl_type_num!(i32, NPY_INT);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,4 +1,4 @@
-extern crate cpython;
+extern crate pyo3;
 extern crate ndarray;
 extern crate numpy;
 
@@ -7,7 +7,7 @@ use numpy::*;
 
 #[test]
 fn new() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
     let n = 3;
     let m = 5;
@@ -19,7 +19,7 @@ fn new() {
 
 #[test]
 fn zeros() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
     let n = 3;
     let m = 5;
@@ -36,7 +36,7 @@ fn zeros() {
 
 #[test]
 fn arange() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
     let arr = PyArray::arange::<f64>(gil.python(), &np, 0.0, 1.0, 0.1);
     println!("ndim = {:?}", arr.ndim());
@@ -46,7 +46,7 @@ fn arange() {
 
 #[test]
 fn as_array() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
     let arr = PyArray::zeros::<f64>(gil.python(), &np, &[3, 2, 4], NPY_CORDER);
     let a = arr.as_array::<f64>().unwrap();
@@ -60,7 +60,7 @@ fn as_array() {
 #[test]
 #[should_panic]
 fn as_array_panic() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
     let arr = PyArray::zeros::<i32>(gil.python(), &np, &[3, 2, 4], NPY_CORDER);
     let _a = arr.as_array::<f32>().unwrap();
@@ -68,7 +68,7 @@ fn as_array_panic() {
 
 #[test]
 fn into_pyarray_vec() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
 
     let a = vec![1, 2, 3];
@@ -80,7 +80,7 @@ fn into_pyarray_vec() {
 
 #[test]
 fn into_pyarray_array() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
 
     let a = Array3::<f64>::zeros((3, 4, 2));
@@ -97,7 +97,7 @@ fn into_pyarray_array() {
 
 #[test]
 fn iter_to_pyarray() {
-    let gil = cpython::Python::acquire_gil();
+    let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
     let arr = (0..10).map(|x| x * x).to_pyarray(gil.python(), &np);
     println!("arr.shape = {:?}", arr.shape());

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,7 +1,6 @@
-
 extern crate cpython;
-extern crate numpy;
 extern crate ndarray;
+extern crate numpy;
 
 use ndarray::*;
 use numpy::*;
@@ -52,8 +51,10 @@ fn as_array() {
     let arr = PyArray::zeros::<f64>(gil.python(), &np, &[3, 2, 4], NPY_CORDER);
     let a = arr.as_array::<f64>().unwrap();
     assert_eq!(arr.shape(), a.shape());
-    assert_eq!(arr.strides().iter().map(|x| x / 8).collect::<Vec<_>>(),
-               a.strides());
+    assert_eq!(
+        arr.strides().iter().map(|x| x / 8).collect::<Vec<_>>(),
+        a.strides()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Resolve #23 

- It is hard to support both PyO3 and rust-cpython interface.
  - rust-numpy 0.2.* uses rust-cpython, and will be deprecated after PyO3 can be compiled with stable Rust https://github.com/PyO3/pyo3/issues/5
  - rust-numpy 0.3 uses PyO3

TODO
--------
- [x] Replace rust-cpython -> PyO3
- [ ] Adopt to PyO3 interface
- [ ] Fix CI (since PyO3 needs nightly)