### PR TITLE
Fix example

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,4 +1,5 @@
 build/
 *.so
 *.egg-info/
+**/dist/
 __pycache__

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 
 [lib]
-name = "rust_ext"
+name = "numpy_rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
@@ -12,5 +12,6 @@ numpy = { path = "../.." }
 ndarray = "0.10"
 
 [dependencies.pyo3]
-version = "*"
+git = "https://github.com/PyO3/pyo3.git"
+rev = "4169b0317826dc62eafcdd0faab7d009f6808c06"
 features = ["extension-module"]

--- a/example/rust_ext/__init__.py
+++ b/example/rust_ext/__init__.py
@@ -1,1 +1,1 @@
-from ._rust_ext import *
+from numpy_rust_ext._rust_ext import *

--- a/example/setup.py
+++ b/example/setup.py
@@ -1,11 +1,38 @@
 
-from setuptools import setup
+import os
+import subprocess
+import sys
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
 from setuptools_rust import RustExtension, Binding
 
-setup(name='rust_ext',
-      version='1.0',
-      rust_extensions=[
-          RustExtension('rust_ext._rust_ext', 'extensions/Cargo.toml',
-                        binding=Binding.RustCPython)],
-      packages=['rust_ext'],
-      zip_safe=False)
+
+class CmdTest(TestCommand):
+    def run(self):
+        self.run_command("test_rust")
+        test_files = os.listdir('./tests')
+        ok = 0
+        for f in test_files:
+            _, ext = os.path.splitext(f)
+            if ext == '.py':
+                res = subprocess.call([sys.executable, f], cwd='./tests')
+                ok = ok | res
+        sys.exit(res)
+
+
+setup_requires = ['setuptools-rust>=0.6.0']
+install_requires = ['numpy']
+test_requires = install_requires
+
+setup(
+    name='rust_ext',
+    version='0.1.0',
+    description='Example of python-extension using rust-numpy',
+    rust_extensions=[RustExtension('numpy_rust_ext._rust_ext', 'extensions/Cargo.toml')],
+    install_requires=install_requires,
+    setup_requires=setup_requires,
+    test_requires=test_requires,
+    packages=find_packages(),
+    zip_safe=False,
+    cmdclass=dict(test=CmdTest)
+)

--- a/example/test.py
+++ b/example/test.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-
-import rust_ext
-import numpy as np
-
-x = np.array([1.0, 2.0])
-y = np.array([2.0, 3.0])
-result = rust_ext.axpy(3, x, y)
-print(result)

--- a/example/tests/test_ext.py
+++ b/example/tests/test_ext.py
@@ -1,0 +1,22 @@
+import numpy as np
+from rust_ext import axpy, mult
+import unittest
+
+class TestExt(unittest.TestCase):
+    """Test class for rust functions
+    """
+
+    def test_axpy(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([3.0, 3.0, 3.0])
+        z = axpy(3.0, x, y)
+        np.testing.assert_array_almost_equal(z, np.array([6.0, 9.0, 12.0]))
+
+    def test_mult(self):
+        x = np.array([1.0, 2.0, 3.0])
+        mult(3.0, x)
+        np.testing.assert_array_almost_equal(x, np.array([3.0, 6.0, 9.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,6 +14,12 @@ use super::*;
 pub struct PyArray(PyObject);
 pyobject_native_type!(PyArray, *npyffi::PyArray_Type_Ptr, npyffi::PyArray_Check);
 
+impl IntoPyObject for PyArray {
+    fn into_object(self, _py: Python) -> PyObject {
+        self.0
+    }
+}
+
 impl PyArray {
     pub fn as_array_ptr(&self) -> *mut npyffi::PyArrayObject {
         self.as_ptr() as _


### PR DESCRIPTION
Suddenly now this hack
```rust
#[pymodinit(_rust_ext)]
 fn init_module(py: Python, m: &PyModule) -> PyResult<()> {
    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    // You **must** write this sentence for PyArray type checker working correctly
    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    let _np = PyArrayModule::import(py)?;
```
is necessary.