### PR TITLE
Upgrade to pyo3 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,4 @@ license-file = "LICENSE"
 libc = "0.2"
 num-complex = "0.1"
 ndarray = "0.10"
-
-[dependencies.pyo3]
-git = "https://github.com/PyO3/pyo3"
-rev = "4169b0317826dc62eafcdd0faab7d009f6808c06"
+pyo3 = "0.3.1"

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -4,14 +4,10 @@ version = "0.1.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 
 [lib]
-name = "numpy_rust_ext"
+name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
 ndarray = "0.10"
-
-[dependencies.pyo3]
-git = "https://github.com/PyO3/pyo3.git"
-rev = "4169b0317826dc62eafcdd0faab7d009f6808c06"
-features = ["extension-module"]
+pyo3 = "0.3.1"

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, specialization)]
+#![feature(use_extern_macros, specialization)]
 
 extern crate ndarray;
 extern crate numpy;
@@ -6,10 +6,10 @@ extern crate pyo3;
 
 use ndarray::*;
 use numpy::*;
-use pyo3::{py::modinit as pymodinit, PyModule, PyResult, Python};
+use pyo3::prelude::*;
 
-#[pymodinit(_rust_ext)]
-fn init_module(py: Python, m: &PyModule) -> PyResult<()> {
+#[pymodinit]
+fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // You **must** write this sentence for PyArray type checker working correctly
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/example/rust_ext/__init__.py
+++ b/example/rust_ext/__init__.py
@@ -1,1 +1,1 @@
-from numpy_rust_ext._rust_ext import *
+from .rust_ext import *

--- a/example/setup.py
+++ b/example/setup.py
@@ -28,7 +28,7 @@ setup(
     name='rust_ext',
     version='0.1.0',
     description='Example of python-extension using rust-numpy',
-    rust_extensions=[RustExtension('numpy_rust_ext._rust_ext', 'extensions/Cargo.toml')],
+    rust_extensions=[RustExtension('rust_ext.rust_ext', 'extensions/Cargo.toml')],
     install_requires=install_requires,
     setup_requires=setup_requires,
     test_requires=test_requires,


### PR DESCRIPTION
The hygiene rules changed in recent nightlies, breaking the macros, which is fixed in 0.3.1.