### PR TITLE
Modify PyArray::shape & PyArray::strides to return slice

### DIFF
--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,6 +1,6 @@
-extern crate pyo3;
 extern crate ndarray;
 extern crate numpy;
+extern crate pyo3;
 
 use ndarray::*;
 use numpy::*;
@@ -91,8 +91,8 @@ fn into_pyarray_array() {
     let pa = a.into_pyarray(gil.python(), &np);
     println!("pa.shape   = {:?}", pa.shape());
     println!("pa.strides = {:?}", pa.strides());
-    assert_eq!(pa.shape(), shape);
-    assert_eq!(pa.strides(), strides);
+    assert_eq!(pa.shape(), shape.as_slice());
+    assert_eq!(pa.strides(), strides.as_slice());
 }
 
 #[test]


### PR DESCRIPTION
I know it can't be bottle neck, but some rust user don't like useless allocation so I think it's better to return slice.
This PR also includes
- Modification of doc links. I think Python API link is more user friendly than C-API link
- Add doc some doc examples