### PR TITLE
Implement IntoPyArray for small array types

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -41,6 +41,30 @@ impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
     }
 }
 
+macro_rules! array_impls {
+    ($($N: expr)+) => {
+        $(
+            impl<T: TypeNum> IntoPyArray for [T; $N] {
+                fn into_pyarray(mut self, py: Python, np: &PyArrayModule) -> PyArray {
+                    let dims = [$N];
+                    let ptr = &mut self as *mut [T; $N];
+                    unsafe {
+                        PyArray::new_::<T>(py, np, &dims, null_mut(), ptr as *mut c_void)
+                    }
+                }
+            }
+        )+
+    }
+}
+
+array_impls! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
+}
+
+
 pub(crate) unsafe fn into_raw<T>(x: Vec<T>) -> *mut c_void {
     let ptr = Box::into_raw(x.into_boxed_slice());
     ptr as *mut c_void

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -136,3 +136,13 @@ fn from_vec3() {
         array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]].into_dyn()
     );
 }
+
+
+#[test]
+fn from_small_array() {
+    let gil = pyo3::Python::acquire_gil();
+    let np = PyArrayModule::import(gil.python()).unwrap();
+    let array: [i32; 5] = [1, 2, 3, 4, 5];
+    let pyarray = array.into_pyarray(gil.python(), &np);
+    assert_eq!(pyarray.as_slice::<i32>().unwrap(), &[1, 2, 3, 4, 5]);
+}


### PR DESCRIPTION
Implement `IntoPyArray` for `[T; 1]` to `[T; 32]`