### PR TITLE
Static type checking with PhantomData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ license-file = "LICENSE"
 libc = "0.2"
 num-complex = "0.1"
 ndarray = "0.11"
-pyo3 = { git =  "https://github.com/kngwyu/pyo3", branch = "native-type-with-generics"}
+pyo3 = { git =  "https://github.com/pyo3/pyo3", rev = "547fa35604a61d2d750390940ed5a0d34ed09821"}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,8 @@ license-file = "LICENSE"
 libc = "0.2"
 num-complex = "0.1"
 ndarray = "0.11"
-pyo3 = "0.3.1"
+pyo3 = { git =  "https://github.com/kngwyu/pyo3", branch = "native-type-with-generics"}
+
+[features]
+default = []
+pyo3-reexport = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ num-complex = "0.1"
 ndarray = "0.11"
 pyo3 = { git =  "https://github.com/kngwyu/pyo3", branch = "native-type-with-generics"}
 
-[features]
-default = []
-pyo3-reexport = []

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-pyo3 = { git =  "https://github.com/kngwyu/pyo3", branch = "native-type-with-generics"}
+pyo3 = { git =  "https://github.com/pyo3/pyo3", rev = "547fa35604a61d2d750390940ed5a0d34ed09821"}
 ndarray = "0.11"

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -8,5 +8,6 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-numpy = { path = "../..", features = ["pyo3-reexport"] }
+numpy = { path = "../.." }
+pyo3 = { git =  "https://github.com/kngwyu/pyo3", branch = "native-type-with-generics"}
 ndarray = "0.11"

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -8,6 +8,5 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-numpy = { path = "../.." }
+numpy = { path = "../..", features = ["pyo3-reexport"] }
 ndarray = "0.11"
-pyo3 = "0.3.1"

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -2,10 +2,11 @@
 
 extern crate ndarray;
 extern crate numpy;
+extern crate pyo3;
 
 use ndarray::*;
 use numpy::*;
-use numpy::pyo3::prelude::*;
+use pyo3::prelude::*;
 
 #[pymodinit]
 fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -2,11 +2,10 @@
 
 extern crate ndarray;
 extern crate numpy;
-extern crate pyo3;
 
 use ndarray::*;
 use numpy::*;
-use pyo3::prelude::*;
+use numpy::pyo3::prelude::*;
 
 #[pymodinit]
 fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
@@ -27,7 +26,7 @@ fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
 
     // wrapper of `axpy`
     #[pyfn(m, "axpy")]
-    fn axpy_py(py: Python, a: f64, x: &PyArray, y: &PyArray) -> PyResult<PyArray> {
+    fn axpy_py(py: Python, a: f64, x: &PyArray<f64>, y: &PyArray<f64>) -> PyResult<PyArray<f64>> {
         let np = PyArrayModule::import(py)?;
         let x = x.as_array().into_pyresult("x must be f64 array")?;
         let y = y.as_array().into_pyresult("y must be f64 array")?;
@@ -36,7 +35,7 @@ fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
-    fn mult_py(_py: Python, a: f64, x: &PyArray) -> PyResult<()> {
+    fn mult_py(_py: Python, a: f64, x: &PyArray<f64>) -> PyResult<()> {
         let x = x.as_array_mut().into_pyresult("x must be f64 array")?;
         mult(a, x);
         Ok(())

--- a/example/setup.py
+++ b/example/setup.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
-from setuptools_rust import RustExtension, Binding
+from setuptools_rust import RustExtension
 
 
 class CmdTest(TestCommand):

--- a/src/array.rs
+++ b/src/array.rs
@@ -3,7 +3,7 @@
 use ndarray::*;
 use npyffi;
 use pyo3::*;
-
+use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr::null_mut;
 
@@ -11,21 +11,117 @@ use super::error::ArrayCastError;
 use super::*;
 
 /// Untyped safe interface for NumPy ndarray.
-pub struct PyArray(PyObject);
-pyobject_native_type!(PyArray, *npyffi::PyArray_Type_Ptr, npyffi::PyArray_Check);
+pub struct PyArray<T>(PyObject, PhantomData<T>);
 
-impl IntoPyObject for PyArray {
+pyobject_native_type!(
+    PyArray<T>,
+    *npyffi::PyArray_Type_Ptr,
+    npyffi::PyArray_Check,
+    T
+);
+
+impl<T> IntoPyObject for PyArray<T> {
     fn into_object(self, _py: Python) -> PyObject {
         self.0
     }
 }
 
-impl PyArray {
+impl<T> PyArray<T> {
     /// Get raw pointer for PyArrayObject
     pub fn as_array_ptr(&self) -> *mut npyffi::PyArrayObject {
         self.as_ptr() as _
     }
 
+    pub unsafe fn from_owned_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> Self {
+        let obj = PyObject::from_owned_ptr(py, ptr);
+        PyArray(obj, PhantomData)
+    }
+
+    pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> Self {
+        let obj = PyObject::from_borrowed_ptr(py, ptr);
+        PyArray(obj, PhantomData)
+    }
+
+    /// Returns the number of dimensions in the array.
+    ///
+    /// Same as [numpy.ndarray.ndim](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ndim.html)
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::{PyArray, PyArrayModule};
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let np = PyArrayModule::import(gil.python()).unwrap();
+    /// let arr = PyArray::<f64>::new(gil.python(), &np, &[4, 5, 6]);
+    /// assert_eq!(arr.ndim(), 3);
+    /// # }
+    /// ```
+    // C API: https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_NDIM
+    pub fn ndim(&self) -> usize {
+        let ptr = self.as_array_ptr();
+        unsafe { (*ptr).nd as usize }
+    }
+
+    /// Returns a slice which contains how many bytes you need to jump to the next row.
+    ///
+    /// Same as [numpy.ndarray.strides](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.strides.html)
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::{PyArray, PyArrayModule};
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let np = PyArrayModule::import(gil.python()).unwrap();
+    /// let arr = PyArray::<f64>::new(gil.python(), &np, &[4, 5, 6]);
+    /// assert_eq!(arr.strides(), &[240, 48, 8]);
+    /// # }
+    /// ```
+    // C API: https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_STRIDES
+    pub fn strides(&self) -> &[isize] {
+        let n = self.ndim();
+        let ptr = self.as_array_ptr();
+        unsafe {
+            let p = (*ptr).strides;
+            ::std::slice::from_raw_parts(p, n)
+        }
+    }
+
+    /// Returns a slice which contains dimmensions of the array.
+    ///
+    /// Same as [numpy.ndarray.shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html)
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::{PyArray, PyArrayModule};
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let np = PyArrayModule::import(gil.python()).unwrap();
+    /// let arr = PyArray::<f64>::new(gil.python(), &np, &[4, 5, 6]);
+    /// assert_eq!(arr.shape(), &[4, 5, 6]);
+    /// # }
+    /// ```
+    // C API: https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_DIMS
+    pub fn shape(&self) -> &[usize] {
+        let n = self.ndim();
+        let ptr = self.as_array_ptr();
+        unsafe {
+            let p = (*ptr).dimensions as *mut usize;
+            ::std::slice::from_raw_parts(p, n)
+        }
+    }
+
+    /// Same as [shape](./struct.PyArray.html#method.shape)
+    ///
+    /// Reserved for backward compatibility.
+    #[inline]
+    pub fn dims(&self) -> &[usize] {
+        self.shape()
+    }
+
+    pub fn len(&self) -> usize {
+        self.shape().iter().fold(1, |a, b| a * b)
+    }
+}
+
+impl<T: TypeNum> PyArray<T> {
     /// Construct one-dimension PyArray from boxed slice.
     ///
     /// # Example
@@ -35,11 +131,11 @@ impl PyArray {
     /// let gil = pyo3::Python::acquire_gil();
     /// let np = PyArrayModule::import(gil.python()).unwrap();
     /// let slice = vec![1, 2, 3, 4, 5].into_boxed_slice();
-    /// let pyarray = PyArray::from_boxed_slice::<u32>(gil.python(), &np, slice);
-    /// assert_eq!(pyarray.as_slice::<u32>().unwrap(), &[1, 2, 3, 4, 5]);
+    /// let pyarray = PyArray::from_boxed_slice(gil.python(), &np, slice);
+    /// assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3, 4, 5]);
     /// # }
     /// ```
-    pub fn from_boxed_slice<T: TypeNum>(py: Python, np: &PyArrayModule, v: Box<[T]>) -> PyArray {
+    pub fn from_boxed_slice(py: Python, np: &PyArrayModule, v: Box<[T]>) -> PyArray<T> {
         IntoPyArray::into_pyarray(v, py, np)
     }
 
@@ -51,11 +147,11 @@ impl PyArray {
     /// use numpy::{PyArray, PyArrayModule};
     /// let gil = pyo3::Python::acquire_gil();
     /// let np = PyArrayModule::import(gil.python()).unwrap();
-    /// let pyarray = PyArray::from_vec::<u32>(gil.python(), &np, vec![1, 2, 3, 4, 5]);
-    /// assert_eq!(pyarray.as_slice::<u32>().unwrap(), &[1, 2, 3, 4, 5]);
+    /// let pyarray = PyArray::from_vec(gil.python(), &np, vec![1, 2, 3, 4, 5]);
+    /// assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3, 4, 5]);
     /// # }
     /// ```
-    pub fn from_vec<T: TypeNum>(py: Python, np: &PyArrayModule, v: Vec<T>) -> PyArray {
+    pub fn from_vec(py: Python, np: &PyArrayModule, v: Vec<T>) -> PyArray<T> {
         IntoPyArray::into_pyarray(v, py, np)
     }
 
@@ -71,16 +167,16 @@ impl PyArray {
     /// let gil = pyo3::Python::acquire_gil();
     /// let np = PyArrayModule::import(gil.python()).unwrap();
     /// let vec2 = vec![vec![1, 2, 3]; 2];
-    /// let pyarray = PyArray::from_vec2::<u32>(gil.python(), &np, &vec2).unwrap();
-    /// assert_eq!(pyarray.as_array::<u32>().unwrap(), array![[1, 2, 3], [1, 2, 3]].into_dyn());
-    /// assert!(PyArray::from_vec2::<u32>(gil.python(), &np, &vec![vec![1], vec![2, 3]]).is_err());
+    /// let pyarray = PyArray::from_vec2(gil.python(), &np, &vec2).unwrap();
+    /// assert_eq!(pyarray.as_array().unwrap(), array![[1, 2, 3], [1, 2, 3]].into_dyn());
+    /// assert!(PyArray::from_vec2(gil.python(), &np, &vec![vec![1], vec![2, 3]]).is_err());
     /// # }
     /// ```
-    pub fn from_vec2<T: TypeNum>(
+    pub fn from_vec2(
         py: Python,
         np: &PyArrayModule,
         v: &Vec<Vec<T>>,
-    ) -> Result<PyArray, ArrayCastError> {
+    ) -> Result<PyArray<T>, ArrayCastError> {
         let last_len = v.last().map_or(0, |v| v.len());
         if v.iter().any(|v| v.len() != last_len) {
             return Err(ArrayCastError::FromVec);
@@ -89,7 +185,7 @@ impl PyArray {
         let flattend: Vec<_> = v.iter().cloned().flatten().collect();
         unsafe {
             let data = convert::into_raw(flattend);
-            Ok(PyArray::new_::<T>(py, np, &dims, null_mut(), data))
+            Ok(PyArray::new_(py, np, &dims, null_mut(), data))
         }
     }
 
@@ -105,19 +201,19 @@ impl PyArray {
     /// let gil = pyo3::Python::acquire_gil();
     /// let np = PyArrayModule::import(gil.python()).unwrap();
     /// let vec2 = vec![vec![vec![1, 2]; 2]; 2];
-    /// let pyarray = PyArray::from_vec3::<u32>(gil.python(), &np, &vec2).unwrap();
+    /// let pyarray = PyArray::from_vec3(gil.python(), &np, &vec2).unwrap();
     /// assert_eq!(
-    ///     pyarray.as_array::<u32>().unwrap(),
+    ///     pyarray.as_array().unwrap(),
     ///     array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]].into_dyn()
     /// );
-    /// assert!(PyArray::from_vec3::<u32>(gil.python(), &np, &vec![vec![vec![1], vec![]]]).is_err());
+    /// assert!(PyArray::from_vec3(gil.python(), &np, &vec![vec![vec![1], vec![]]]).is_err());
     /// # }
     /// ```
-    pub fn from_vec3<T: TypeNum>(
+    pub fn from_vec3(
         py: Python,
         np: &PyArrayModule,
         v: &Vec<Vec<Vec<T>>>,
-    ) -> Result<PyArray, ArrayCastError> {
+    ) -> Result<PyArray<T>, ArrayCastError> {
         let dim2 = v.last().map_or(0, |v| v.len());
         if v.iter().any(|v| v.len() != dim2) {
             return Err(ArrayCastError::FromVec);
@@ -130,7 +226,7 @@ impl PyArray {
         let flattend: Vec<_> = v.iter().flat_map(|v| v.iter().cloned().flatten()).collect();
         unsafe {
             let data = convert::into_raw(flattend);
-            Ok(PyArray::new_::<T>(py, np, &dims, null_mut(), data))
+            Ok(PyArray::new_(py, np, &dims, null_mut(), data))
         }
     }
 
@@ -142,118 +238,29 @@ impl PyArray {
     /// use numpy::{PyArray, PyArrayModule};
     /// let gil = pyo3::Python::acquire_gil();
     /// let np = PyArrayModule::import(gil.python()).unwrap();
-    /// let pyarray = PyArray::from_ndarray::<u32, _>(gil.python(), &np, array![[1, 2], [3, 4]]);
-    /// assert_eq!(pyarray.as_array::<u32>().unwrap(), array![[1, 2], [3, 4]].into_dyn());
+    /// let pyarray = PyArray::from_ndarray(gil.python(), &np, array![[1, 2], [3, 4]]);
+    /// assert_eq!(pyarray.as_array().unwrap(), array![[1, 2], [3, 4]].into_dyn());
     /// # }
     /// ```
-    pub fn from_ndarray<A, D>(py: Python, np: &PyArrayModule, arr: Array<A, D>) -> PyArray
+    pub fn from_ndarray<D>(py: Python, np: &PyArrayModule, arr: Array<T, D>) -> PyArray<T>
     where
-        A: TypeNum,
         D: Dimension,
     {
         IntoPyArray::into_pyarray(arr, py, np)
     }
 
-    pub unsafe fn from_owned_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> Self {
-        let obj = PyObject::from_owned_ptr(py, ptr);
-        PyArray(obj)
-    }
-
-    pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> Self {
-        let obj = PyObject::from_borrowed_ptr(py, ptr);
-        PyArray(obj)
-    }
-
-    /// Returns the number of dimensions in the array.
-    ///
-    /// Same as [numpy.ndarray.ndim](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ndim.html)
-    ///
-    /// # Example
-    /// ```
-    /// # extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::{PyArray, PyArrayModule};
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let np = PyArrayModule::import(gil.python()).unwrap();
-    /// let arr = PyArray::new::<f64>(gil.python(), &np, &[4, 5, 6]);
-    /// assert_eq!(arr.ndim(), 3);
-    /// # }
-    /// ```
-    // C API: https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_NDIM
-    pub fn ndim(&self) -> usize {
-        let ptr = self.as_array_ptr();
-        unsafe { (*ptr).nd as usize }
-    }
-
-    /// Same as [shape](./struct.PyArray.html#method.shape)
-    ///
-    /// Reserved for backward compatibility.
-    #[inline]
-    pub fn dims(&self) -> &[usize] {
-        self.shape()
-    }
-
-    pub fn len(&self) -> usize {
-        self.shape().iter().fold(1, |a, b| a * b)
-    }
-
-    /// Returns a slice which contains dimmensions of the array.
-    ///
-    /// Same as [numpy.ndarray.shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html)
-    /// # Example
-    /// ```
-    /// # extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::{PyArray, PyArrayModule};
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let np = PyArrayModule::import(gil.python()).unwrap();
-    /// let arr = PyArray::new::<f64>(gil.python(), &np, &[4, 5, 6]);
-    /// assert_eq!(arr.shape(), &[4, 5, 6]);
-    /// # }
-    /// ```
-    // C API: https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_DIMS
-    pub fn shape(&self) -> &[usize] {
-        let n = self.ndim();
-        let ptr = self.as_array_ptr();
-        unsafe {
-            let p = (*ptr).dimensions as *mut usize;
-            ::std::slice::from_raw_parts(p, n)
-        }
-    }
-
-    /// Returns a slice which contains how many bytes you need to jump to the next row.
-    ///
-    /// Same as [numpy.ndarray.strides](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.strides.html)
-    /// # Example
-    /// ```
-    /// # extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::{PyArray, PyArrayModule};
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let np = PyArrayModule::import(gil.python()).unwrap();
-    /// let arr = PyArray::new::<f64>(gil.python(), &np, &[4, 5, 6]);
-    /// assert_eq!(arr.strides(), &[240, 48, 8]);
-    /// # }
-    /// ```
-    // C API: https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_STRIDES
-    pub fn strides(&self) -> &[isize] {
-        let n = self.ndim();
-        let ptr = self.as_array_ptr();
-        unsafe {
-            let p = (*ptr).strides;
-            ::std::slice::from_raw_parts(p, n)
-        }
-    }
-
-    unsafe fn data<T>(&self) -> *mut T {
+    unsafe fn data(&self) -> *mut T {
         let ptr = self.as_array_ptr();
         (*ptr).data as *mut T
     }
 
-    fn ndarray_shape<A>(&self) -> StrideShape<IxDyn> {
+    fn ndarray_shape(&self) -> StrideShape<IxDyn> {
         // FIXME may be done more simply
         let shape: Shape<_> = Dim(self.shape()).into();
         let st: Vec<usize> = self
             .strides()
             .iter()
-            .map(|&x| x as usize / ::std::mem::size_of::<A>())
+            .map(|&x| x as usize / ::std::mem::size_of::<T>())
             .collect();
         shape.strides(Dim(st))
     }
@@ -265,10 +272,10 @@ impl PyArray {
         }
     }
 
-    fn type_check<A: types::TypeNum>(&self) -> Result<(), ArrayCastError> {
-        let test = A::typenum();
+    fn type_check(&self) -> Result<(), ArrayCastError> {
+        let test = T::typenum();
         let truth = self.typenum();
-        if A::typenum() == self.typenum() {
+        if test == truth {
             Ok(())
         } else {
             Err(ArrayCastError::to_rust(test, truth))
@@ -276,40 +283,35 @@ impl PyArray {
     }
 
     /// Get data as a ndarray::ArrayView
-    pub fn as_array<A: types::TypeNum>(&self) -> Result<ArrayViewD<A>, ArrayCastError> {
-        self.type_check::<A>()?;
-        unsafe {
-            Ok(ArrayView::from_shape_ptr(
-                self.ndarray_shape::<A>(),
-                self.data(),
-            ))
-        }
+    pub fn as_array(&self) -> Result<ArrayViewD<T>, ArrayCastError> {
+        self.type_check()?;
+        unsafe { Ok(ArrayView::from_shape_ptr(self.ndarray_shape(), self.data())) }
     }
 
     /// Get data as a ndarray::ArrayViewMut
-    pub fn as_array_mut<A: types::TypeNum>(&self) -> Result<ArrayViewMutD<A>, ArrayCastError> {
-        self.type_check::<A>()?;
+    pub fn as_array_mut(&self) -> Result<ArrayViewMutD<T>, ArrayCastError> {
+        self.type_check()?;
         unsafe {
             Ok(ArrayViewMut::from_shape_ptr(
-                self.ndarray_shape::<A>(),
+                self.ndarray_shape(),
                 self.data(),
             ))
         }
     }
 
     /// Get data as a Rust immutable slice
-    pub fn as_slice<A: types::TypeNum>(&self) -> Result<&[A], ArrayCastError> {
-        self.type_check::<A>()?;
+    pub fn as_slice(&self) -> Result<&[T], ArrayCastError> {
+        self.type_check()?;
         unsafe { Ok(::std::slice::from_raw_parts(self.data(), self.len())) }
     }
 
     /// Get data as a Rust mutable slice
-    pub fn as_slice_mut<A: types::TypeNum>(&self) -> Result<&mut [A], ArrayCastError> {
-        self.type_check::<A>()?;
+    pub fn as_slice_mut(&self) -> Result<&mut [T], ArrayCastError> {
+        self.type_check()?;
         unsafe { Ok(::std::slice::from_raw_parts_mut(self.data(), self.len())) }
     }
 
-    pub unsafe fn new_<T: types::TypeNum>(
+    pub unsafe fn new_(
         py: Python,
         np: &PyArrayModule,
         dims: &[usize],
@@ -332,17 +334,12 @@ impl PyArray {
     }
 
     /// a wrapper of [PyArray_SimpleNew](https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_SimpleNew)
-    pub fn new<T: TypeNum>(py: Python, np: &PyArrayModule, dims: &[usize]) -> Self {
-        unsafe { Self::new_::<T>(py, np, dims, null_mut(), null_mut()) }
+    pub fn new(py: Python, np: &PyArrayModule, dims: &[usize]) -> Self {
+        unsafe { Self::new_(py, np, dims, null_mut(), null_mut()) }
     }
 
     /// a wrapper of [PyArray_ZEROS](https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_ZEROS)
-    pub fn zeros<T: TypeNum>(
-        py: Python,
-        np: &PyArrayModule,
-        dims: &[usize],
-        order: NPY_ORDER,
-    ) -> Self {
+    pub fn zeros(py: Python, np: &PyArrayModule, dims: &[usize], order: NPY_ORDER) -> Self {
         let dims: Vec<npy_intp> = dims.iter().map(|d| *d as npy_intp).collect();
         unsafe {
             let descr = np.PyArray_DescrFromType(T::typenum());
@@ -357,13 +354,7 @@ impl PyArray {
     }
 
     /// a wrapper of [PyArray_Arange](https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_Arange)
-    pub fn arange<T: TypeNum>(
-        py: Python,
-        np: &PyArrayModule,
-        start: f64,
-        stop: f64,
-        step: f64,
-    ) -> Self {
+    pub fn arange(py: Python, np: &PyArrayModule, start: f64, stop: f64, step: f64) -> Self {
         unsafe {
             let ptr = np.PyArray_Arange(start, stop, step, T::typenum());
             Self::from_owned_ptr(py, ptr)

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -70,7 +70,6 @@ array_impls! {
     30 31 32
 }
 
-
 pub(crate) unsafe fn into_raw<T>(x: Vec<T>) -> *mut c_void {
     let ptr = Box::into_raw(x.into_boxed_slice());
     ptr as *mut c_void

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@
 use pyo3::*;
 use std::error;
 use std::fmt;
+use types::NpyDataTypes;
 
 pub trait IntoPyErr {
     fn into_pyerr(self, msg: &str) -> PyErr;
@@ -23,21 +24,27 @@ impl<T, E: IntoPyErr> IntoPyResult for Result<T, E> {
 /// Error for casting `PyArray` into `ArrayView` or `ArrayViewMut`
 #[derive(Debug)]
 pub enum ArrayCastError {
-    ToRust { test: i32, truth: i32 },
+    ToRust {
+        from: NpyDataTypes,
+        to: NpyDataTypes,
+    },
     FromVec,
 }
 
 impl ArrayCastError {
-    pub fn to_rust(test: i32, truth: i32) -> Self {
-        ArrayCastError::ToRust { test, truth }
+    pub fn to_rust(from: i32, to: i32) -> Self {
+        ArrayCastError::ToRust {
+            from: NpyDataTypes::from_i32(from),
+            to: NpyDataTypes::from_i32(to),
+        }
     }
 }
 
 impl fmt::Display for ArrayCastError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ArrayCastError::ToRust { test, truth } => {
-                write!(f, "Cast failed: from={}, to={}", test, truth)
+            ArrayCastError::ToRust { from, to } => {
+                write!(f, "Cast failed: from={:?}, to={:?}", from, to)
             }
             ArrayCastError::FromVec => write!(f, "Cast failed: FromVec (maybe invalid dimension)"),
         }
@@ -56,10 +63,11 @@ impl error::Error for ArrayCastError {
 impl IntoPyErr for ArrayCastError {
     fn into_pyerr(self, msg: &str) -> PyErr {
         let msg = match self {
-            ArrayCastError::ToRust { .. } => {
-                format!("rust_numpy::ArrayCastError::IntoArray: {}", msg)
-            }
-            ArrayCastError::FromVec => format!("rust_numpy::ArrayCastError::FromVec: {}", msg),
+            ArrayCastError::ToRust { from, to } => format!(
+                "ArrayCastError::ToRust: from: {:?}, to: {:?}, msg: {}",
+                from, to, msg
+            ),
+            ArrayCastError::FromVec => format!("ArrayCastError::FromVec: {}", msg),
         };
         PyErr::new::<exc::TypeError, _>(msg)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use pyo3::*;
 use std::error;
 use std::fmt;
-use types::NpyDataTypes;
+use types::NpyDataType;
 
 pub trait IntoPyErr {
     fn into_pyerr(self, msg: &str) -> PyErr;
@@ -25,8 +25,8 @@ impl<T, E: IntoPyErr> IntoPyResult for Result<T, E> {
 #[derive(Debug)]
 pub enum ArrayCastError {
     ToRust {
-        from: NpyDataTypes,
-        to: NpyDataTypes,
+        from: NpyDataType,
+        to: NpyDataType,
     },
     FromVec,
 }
@@ -34,8 +34,8 @@ pub enum ArrayCastError {
 impl ArrayCastError {
     pub fn to_rust(from: i32, to: i32) -> Self {
         ArrayCastError::ToRust {
-            from: NpyDataTypes::from_i32(from),
-            to: NpyDataTypes::from_i32(to),
+            from: NpyDataType::from_i32(from),
+            to: NpyDataType::from_i32(to),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,13 @@
 extern crate libc;
 extern crate ndarray;
 extern crate num_complex;
+#[cfg(not(feature = "pyo3-reexport"))]
 #[macro_use]
 extern crate pyo3;
+
+#[cfg(feature = "pyo3-reexport")]
+#[macro_use]
+pub extern crate pyo3;
 
 pub mod array;
 pub mod convert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,8 @@
 extern crate libc;
 extern crate ndarray;
 extern crate num_complex;
-#[cfg(not(feature = "pyo3-reexport"))]
 #[macro_use]
 extern crate pyo3;
-
-#[cfg(feature = "pyo3-reexport")]
-#[macro_use]
-pub extern crate pyo3;
 
 pub mod array;
 pub mod convert;

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -60,6 +60,32 @@ impl<'py> PyArrayModule<'py> {
         Ok(mod_)
     }
 
+    /// Returns internal `PyModule` type, which includes `numpy.core.multiarray`,
+    /// so that you can use `PyArrayModule` with some pyo3 functions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate numpy; extern crate pyo3; fn main() {
+    /// use numpy::*;
+    /// use pyo3::prelude::*;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let np = PyArrayModule::import(gil.python()).unwrap();
+    /// let dict = PyDict::new(gil.python());
+    /// dict.set_item("np", np.as_pymodule()).unwrap();
+    /// let pyarray: &PyArray<i32> = gil
+    ///     .python()
+    ///     .eval("np.array([1, 2, 3], dtype='int32')", Some(&dict), None)
+    ///     .unwrap()
+    ///     .extract()
+    ///     .unwrap();
+    /// assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3]);
+    /// # }
+    /// ```
+    pub fn as_pymodule(&self) -> &'py PyModule {
+        self.numpy
+    }
+
     pyarray_api![0; PyArray_GetNDArrayCVersion() -> c_uint];
     pyarray_api![40; PyArray_SetNumericOps(dict: *mut PyObject) -> c_int];
     pyarray_api![41; PyArray_GetNumericOps() -> *mut PyObject];

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -57,6 +57,10 @@ impl<'py> PyUFuncModule<'py> {
         *self.api as *mut PyTypeObject
     }
 
+    pub fn as_pymodule(&self) -> &'py PyModule {
+        self.numpy
+    }
+
     pyufunc_api![1; PyUFunc_FromFuncAndData(func: *mut PyUFuncGenericFunction, data: *mut *mut c_void, types: *mut c_char, ntypes: c_int, nin: c_int, nout: c_int, identity: c_int, name: *const c_char, doc: *const c_char, unused: c_int) -> *mut PyObject];
     pyufunc_api![2; PyUFunc_RegisterLoopForType(ufunc: *mut PyUFuncObject, usertype: c_int, function: PyUFuncGenericFunction, arg_types: *mut c_int, data: *mut c_void) -> c_int];
     pyufunc_api![3; PyUFunc_GenericFunction(ufunc: *mut PyUFuncObject, args: *mut PyObject, kwds: *mut PyObject, op: *mut *mut PyArrayObject) -> c_int];

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,29 +7,67 @@ pub use super::npyffi::NPY_ORDER::{NPY_CORDER, NPY_FORTRANORDER};
 
 use super::npyffi::NPY_TYPES;
 
+/// An enum type represents numpy data type.
+///
+/// This type is mainly for displaying error, and user don't have to use it directly.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NpyDataTypes {
+    Bool,
+    Int32,
+    Int64,
+    Uint32,
+    Uint64,
+    Float32,
+    Float64,
+    Complex32,
+    Complex64,
+    Unsupported,
+}
+
+impl NpyDataTypes {
+    pub(crate) fn from_i32(npy_t: i32) -> Self {
+        match npy_t {
+            x if x == NPY_TYPES::NPY_BOOL as i32 => NpyDataTypes::Bool,
+            x if x == NPY_TYPES::NPY_INT as i32 => NpyDataTypes::Int32,
+            x if x == NPY_TYPES::NPY_LONG as i32 => NpyDataTypes::Int64,
+            x if x == NPY_TYPES::NPY_UINT as i32 => NpyDataTypes::Uint32,
+            x if x == NPY_TYPES::NPY_ULONG as i32 => NpyDataTypes::Uint64,
+            x if x == NPY_TYPES::NPY_FLOAT as i32 => NpyDataTypes::Float32,
+            x if x == NPY_TYPES::NPY_DOUBLE as i32 => NpyDataTypes::Float64,
+            x if x == NPY_TYPES::NPY_CFLOAT as i32 => NpyDataTypes::Complex32,
+            x if x == NPY_TYPES::NPY_CDOUBLE as i32 => NpyDataTypes::Complex64,
+            _ => NpyDataTypes::Unsupported,
+        }
+    }
+}
+
 pub trait TypeNum: Clone {
     fn typenum_enum() -> NPY_TYPES;
     fn typenum() -> i32 {
         Self::typenum_enum() as i32
     }
+    fn to_npy_data_type(self) -> NpyDataTypes;
 }
 
 macro_rules! impl_type_num {
-    ($t:ty, $npy_t:ident) => {
+    ($t:ty, $npy_t:ident, $npy_dat_t:ident) => {
         impl TypeNum for $t {
             fn typenum_enum() -> NPY_TYPES {
                 NPY_TYPES::$npy_t
+            }
+            fn to_npy_data_type(self) -> NpyDataTypes {
+                NpyDataTypes::$npy_dat_t
             }
         }
     };
 } // impl_type_num!
 
-impl_type_num!(bool, NPY_BOOL);
-impl_type_num!(i32, NPY_INT);
-impl_type_num!(i64, NPY_LONG);
-impl_type_num!(u32, NPY_UINT);
-impl_type_num!(u64, NPY_ULONG);
-impl_type_num!(f32, NPY_FLOAT);
-impl_type_num!(f64, NPY_DOUBLE);
-impl_type_num!(c32, NPY_CFLOAT);
-impl_type_num!(c64, NPY_CDOUBLE);
+impl_type_num!(bool, NPY_BOOL, Bool);
+impl_type_num!(i32, NPY_INT, Int32);
+impl_type_num!(i64, NPY_LONG, Int64);
+impl_type_num!(u32, NPY_UINT, Uint32);
+impl_type_num!(u64, NPY_ULONG, Uint64);
+impl_type_num!(f32, NPY_FLOAT, Float32);
+impl_type_num!(f64, NPY_DOUBLE, Float64);
+impl_type_num!(c32, NPY_CFLOAT, Complex32);
+impl_type_num!(c64, NPY_CDOUBLE, Complex64);

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use super::npyffi::NPY_TYPES;
 ///
 /// This type is mainly for displaying error, and user don't have to use it directly.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum NpyDataTypes {
+pub enum NpyDataType {
     Bool,
     Int32,
     Int64,
@@ -24,19 +24,19 @@ pub enum NpyDataTypes {
     Unsupported,
 }
 
-impl NpyDataTypes {
+impl NpyDataType {
     pub(crate) fn from_i32(npy_t: i32) -> Self {
         match npy_t {
-            x if x == NPY_TYPES::NPY_BOOL as i32 => NpyDataTypes::Bool,
-            x if x == NPY_TYPES::NPY_INT as i32 => NpyDataTypes::Int32,
-            x if x == NPY_TYPES::NPY_LONG as i32 => NpyDataTypes::Int64,
-            x if x == NPY_TYPES::NPY_UINT as i32 => NpyDataTypes::Uint32,
-            x if x == NPY_TYPES::NPY_ULONG as i32 => NpyDataTypes::Uint64,
-            x if x == NPY_TYPES::NPY_FLOAT as i32 => NpyDataTypes::Float32,
-            x if x == NPY_TYPES::NPY_DOUBLE as i32 => NpyDataTypes::Float64,
-            x if x == NPY_TYPES::NPY_CFLOAT as i32 => NpyDataTypes::Complex32,
-            x if x == NPY_TYPES::NPY_CDOUBLE as i32 => NpyDataTypes::Complex64,
-            _ => NpyDataTypes::Unsupported,
+            x if x == NPY_TYPES::NPY_BOOL as i32 => NpyDataType::Bool,
+            x if x == NPY_TYPES::NPY_INT as i32 => NpyDataType::Int32,
+            x if x == NPY_TYPES::NPY_LONG as i32 => NpyDataType::Int64,
+            x if x == NPY_TYPES::NPY_UINT as i32 => NpyDataType::Uint32,
+            x if x == NPY_TYPES::NPY_ULONG as i32 => NpyDataType::Uint64,
+            x if x == NPY_TYPES::NPY_FLOAT as i32 => NpyDataType::Float32,
+            x if x == NPY_TYPES::NPY_DOUBLE as i32 => NpyDataType::Float64,
+            x if x == NPY_TYPES::NPY_CFLOAT as i32 => NpyDataType::Complex32,
+            x if x == NPY_TYPES::NPY_CDOUBLE as i32 => NpyDataType::Complex64,
+            _ => NpyDataType::Unsupported,
         }
     }
 }
@@ -46,7 +46,7 @@ pub trait TypeNum: Clone {
     fn typenum() -> i32 {
         Self::typenum_enum() as i32
     }
-    fn to_npy_data_type(self) -> NpyDataTypes;
+    fn to_npy_data_type(self) -> NpyDataType;
 }
 
 macro_rules! impl_type_num {
@@ -55,8 +55,8 @@ macro_rules! impl_type_num {
             fn typenum_enum() -> NPY_TYPES {
                 NPY_TYPES::$npy_t
             }
-            fn to_npy_data_type(self) -> NpyDataTypes {
-                NpyDataTypes::$npy_dat_t
+            fn to_npy_data_type(self) -> NpyDataType {
+                NpyDataType::$npy_dat_t
             }
         }
     };

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -2,9 +2,9 @@ extern crate ndarray;
 extern crate numpy;
 extern crate pyo3;
 
-use pyo3::prelude::*;
 use ndarray::*;
 use numpy::*;
+use pyo3::prelude::*;
 
 #[test]
 fn new() {
@@ -155,3 +155,18 @@ fn from_eval() {
         .unwrap();
     assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3]);
 }
+
+#[test]
+fn from_eval_fail() {
+    let gil = pyo3::Python::acquire_gil();
+    let np = PyArrayModule::import(gil.python()).unwrap();
+    let dict = PyDict::new(gil.python());
+    dict.set_item("np", np.as_pymodule()).unwrap();
+    let converted: Result<&PyArray<i32>, _> = gil
+        .python()
+        .eval("np.array([1, 2, 3], dtype='float64')", Some(&dict), None)
+        .unwrap()
+        .extract();
+    assert!(converted.is_err());
+}
+

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -2,6 +2,7 @@ extern crate ndarray;
 extern crate numpy;
 extern crate pyo3;
 
+use pyo3::prelude::*;
 use ndarray::*;
 use numpy::*;
 
@@ -138,4 +139,19 @@ fn from_small_array() {
     let array: [i32; 5] = [1, 2, 3, 4, 5];
     let pyarray = array.into_pyarray(gil.python(), &np);
     assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn from_eval() {
+    let gil = pyo3::Python::acquire_gil();
+    let np = PyArrayModule::import(gil.python()).unwrap();
+    let dict = PyDict::new(gil.python());
+    dict.set_item("np", np.as_pymodule()).unwrap();
+    let pyarray: &PyArray<i32> = gil
+        .python()
+        .eval("np.array([1, 2, 3], dtype='int32')", Some(&dict), None)
+        .unwrap()
+        .extract()
+        .unwrap();
+    assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3]);
 }


### PR DESCRIPTION
Currently, this code
```rust
let v: Vec<i32> = vec![1, 2, 3];
let pyarray = PyArray::from_vec::<i64>(py, &np, v);
```
causes panic.
But, isn't it annoying to give a type annotation like `from_vec::<i64>`, and isn't it really user-friendly to cause panic?
So, this PR introduces `PyArray<T>` instead of `PyArray`.
By this change, when we write
```rust
let v: Vec<i32> = vec![1, 2, 3];
let pyarray = PyArray::<i64>::from_vec(py, &np, v);
```
, we can get compile error.

@termoshtt 
This is a breaking change so I want to hear your opnion :slightly_smiling_face: 