### PR TITLE
Remove ToPyArray and Add PyArray::from_iter

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -166,6 +166,24 @@ impl<T: TypeNum> PyArray<T> {
         IntoPyArray::into_pyarray(v, py, np)
     }
 
+    /// Construct one-dimension PyArray from `impl IntoIterator`.
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::{PyArray, PyArrayModule};
+    /// use std::collections::BTreeSet;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let np = PyArrayModule::import(gil.python()).unwrap();
+    /// let set: BTreeSet<u32> = [4, 3, 2, 5, 1].into_iter().cloned().collect();
+    /// let pyarray = PyArray::from_iter(gil.python(), &np, set);
+    /// assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3, 4, 5]);
+    /// # }
+    /// ```
+    pub fn from_iter(py: Python, np: &PyArrayModule, i: impl IntoIterator<Item = T>) -> PyArray<T> {
+        i.into_iter().collect::<Vec<_>>().into_pyarray(py, np)
+    }
+
     /// Construct one-dimension PyArray from Vec.
     ///
     /// # Example

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -74,19 +74,3 @@ pub(crate) unsafe fn into_raw<T>(x: Vec<T>) -> *mut c_void {
     let ptr = Box::into_raw(x.into_boxed_slice());
     ptr as *mut c_void
 }
-
-pub trait ToPyArray {
-    type Item: TypeNum;
-    fn to_pyarray(self, Python, &PyArrayModule) -> PyArray<Self::Item>;
-}
-
-impl<Iter, T: TypeNum> ToPyArray for Iter
-where
-    Iter: Iterator<Item = T> + Sized,
-{
-    type Item = T;
-    fn to_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
-        let vec: Vec<T> = self.collect();
-        vec.into_pyarray(py, np)
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod npyffi;
 pub mod types;
 
 pub use array::PyArray;
-pub use convert::{IntoPyArray, ToPyArray};
+pub use convert::IntoPyArray;
 pub use error::*;
 pub use npyffi::{PyArrayModule, PyUFuncModule};
 pub use types::*;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -91,10 +91,8 @@ fn into_pyarray_array() {
 fn iter_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
     let np = PyArrayModule::import(gil.python()).unwrap();
-    let arr = (0..10).map(|x| x * x).to_pyarray(gil.python(), &np);
-    println!("arr.shape = {:?}", arr.shape());
-    println!("arr = {:?}", arr.as_slice().unwrap());
-    assert_eq!(arr.shape(), [10]);
+    let arr = PyArray::from_iter(gil.python(), &np, (0..10).map(|x| x * x));
+    assert_eq!(arr.as_slice().unwrap(), &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
 }
 
 #[test]


### PR DESCRIPTION
According to [rust API guideline](https://rust-lang-nursery.github.io/api-guidelines/naming.html), we should use `to_` to
- borrowed -> borrowed
- borrowed -> owned (non-Copy types)
- owned -> owned (Copy types) 
but our `to_pyarray` takes `self` for all types.
And, since objects we send to numpy API are controlled by Python GC, I think all Rust->Python conversion APIs consume lifetime, so I decided to remove `ToPyArray` trait.
Instead of this, I added `from_iter` method to `PyArray`, which takes `impl IntoIterator`.