### PR TITLE
Make the example an extension module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ libc = "0.2"
 num-complex = "0.1"
 ndarray = "0.11"
 pyo3 = "0.4.0"
-

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-pyo3 = "0.4.0"
+pyo3 = { version = "0.4.0", features = ["extension-module"] }
 ndarray = "0.11"


### PR DESCRIPTION
This fixes and the build for python3.5 for me and would also be required for publishing on pypi