### PR TITLE
Expose pyo3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,8 @@ cfg-if = "0.1.5"
 libc = "0.2"
 num-complex = "0.1"
 ndarray = "0.11"
-pyo3 = { git = "https://github.com/kngwyu/pyo3.git", branch = "upd" }
+pyo3 = "0.4.1"
+
+[features]
+default = []
+extension = ["pyo3/extension-module"]

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -8,10 +8,8 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-numpy = { path = "../.." }
 ndarray = "0.11"
 
-[dependencies.pyo3]
-git = "https://github.com/kngwyu/pyo3.git"
-branch = "upd"
-features = ["extension-module"]
+[dependencies.numpy]
+path = "../.."
+features = ["extension"]

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -1,11 +1,10 @@
-#![feature(use_extern_macros, specialization)]
+#![feature(specialization)]
 
 extern crate ndarray;
 extern crate numpy;
-extern crate pyo3;
 
-use ndarray::*;
-use numpy::*;
+use ndarray::prelude::*;
+use numpy::{pyo3, PyArray, PyArrayModule, IntoPyResult, IntoPyArray};
 use pyo3::prelude::*;
 
 #[pymodinit]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate libc;
 extern crate ndarray;
 extern crate num_complex;
 #[macro_use]
-extern crate pyo3;
+pub extern crate pyo3;
 
 pub mod array;
 pub mod convert;


### PR DESCRIPTION
Since this crate can work with very few versions(now 0.4.1) of pyo3,
it's more user-friendly to specify what pyo3 version to use.