### PR TITLE
Use PyArrayModule::py instead of taking Python as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
         let np = PyArrayModule::import(py)?;
         let x = x.as_array().into_pyresult("x must be f64 array")?;
         let y = y.as_array().into_pyresult("y must be f64 array")?;
-        Ok(axpy(a, x, y).into_pyarray(py, &np))
+        Ok(axpy(a, x, y).into_pyarray(&np))
     }
 
     // wrapper of `mult`

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -29,7 +29,7 @@ fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
         let np = PyArrayModule::import(py)?;
         let x = x.as_array().into_pyresult("x must be f64 array")?;
         let y = y.as_array().into_pyresult("y must be f64 array")?;
-        Ok(axpy(a, x, y).into_pyarray(py, &np))
+        Ok(axpy(a, x, y).into_pyarray(&np))
     }
 
     // wrapper of `mult`

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,7 +1,6 @@
 //! Defines conversion trait between rust types and numpy data types.
 
 use ndarray::*;
-use pyo3::Python;
 
 use std::iter::Iterator;
 use std::mem::size_of;
@@ -18,35 +17,35 @@ use super::*;
 /// use numpy::{PyArray, PyArrayModule, IntoPyArray};
 /// let gil = pyo3::Python::acquire_gil();
 /// let np = PyArrayModule::import(gil.python()).unwrap();
-/// let py_array = vec![1, 2, 3].into_pyarray(gil.python(), &np);
+/// let py_array = vec![1, 2, 3].into_pyarray(&np);
 /// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
 /// # }
 /// ```
 pub trait IntoPyArray {
     type Item: TypeNum;
-    fn into_pyarray(self, Python, &PyArrayModule) -> PyArray<Self::Item>;
+    fn into_pyarray(self, &PyArrayModule) -> PyArray<Self::Item>;
 }
 
 impl<T: TypeNum> IntoPyArray for Box<[T]> {
     type Item = T;
-    fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
+    fn into_pyarray(self, np: &PyArrayModule) -> PyArray<Self::Item> {
         let dims = [self.len()];
         let ptr = Box::into_raw(self);
-        unsafe { PyArray::new_(py, np, &dims, null_mut(), ptr as *mut c_void) }
+        unsafe { PyArray::new_(np, &dims, null_mut(), ptr as *mut c_void) }
     }
 }
 
 impl<T: TypeNum> IntoPyArray for Vec<T> {
     type Item = T;
-    fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
+    fn into_pyarray(self, np: &PyArrayModule) -> PyArray<Self::Item> {
         let dims = [self.len()];
-        unsafe { PyArray::new_(py, np, &dims, null_mut(), into_raw(self)) }
+        unsafe { PyArray::new_(np, &dims, null_mut(), into_raw(self)) }
     }
 }
 
 impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
     type Item = A;
-    fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
+    fn into_pyarray(self, np: &PyArrayModule) -> PyArray<Self::Item> {
         let dims: Vec<_> = self.shape().iter().cloned().collect();
         let mut strides: Vec<_> = self
             .strides()
@@ -55,7 +54,7 @@ impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
             .collect();
         unsafe {
             let data = into_raw(self.into_raw_vec());
-            PyArray::new_(py, np, &dims, strides.as_mut_ptr(), data)
+            PyArray::new_(np, &dims, strides.as_mut_ptr(), data)
         }
     }
 }
@@ -65,11 +64,11 @@ macro_rules! array_impls {
         $(
             impl<T: TypeNum> IntoPyArray for [T; $N] {
                 type Item = T;
-                fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<T> {
+                fn into_pyarray(self, np: &PyArrayModule) -> PyArray<T> {
                     let dims = [$N];
                     let ptr = Box::into_raw(Box::new(self));
                     unsafe {
-                        PyArray::new_(py, np, &dims, null_mut(), ptr as *mut c_void)
+                        PyArray::new_(np, &dims, null_mut(), ptr as *mut c_void)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!     let gil = Python::acquire_gil();
 //!     let py = gil.python();
 //!     let np = PyArrayModule::import(py).unwrap();
-//!     let py_array = array![[1i64, 2], [3, 4]].into_pyarray(py, &np);
+//!     let py_array = array![[1i64, 2], [3, 4]].into_pyarray(&np);
 //!     assert_eq!(
 //!         py_array.as_array().unwrap(),
 //!         array![[1i64, 2], [3, 4]].into_dyn(),

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -7,7 +7,7 @@ use std::ptr::null_mut;
 
 use pyo3::ffi;
 use pyo3::ffi::{PyObject, PyTypeObject};
-use pyo3::{ObjectProtocol, PyModule, PyResult, Python, ToPyPointer};
+use pyo3::{ObjectProtocol, PyModule, PyObjectWithToken, PyResult, Python, ToPyPointer};
 
 use npyffi::*;
 
@@ -81,6 +81,11 @@ impl<'py> PyArrayModule<'py> {
     /// ```
     pub fn as_pymodule(&self) -> &'py PyModule {
         self.numpy
+    }
+
+    /// Retrieve a Python instance with the same lifetime as PyArrayModule.
+    pub fn py(&self) -> Python<'py> {
+        self.numpy.py()
     }
 
     pyarray_api![0; PyArray_GetNDArrayCVersion() -> c_uint];


### PR DESCRIPTION
Since `PyModule` has `PyObjectWithToken` implementation, sometimes we don't need take `Python` as function as argument(because`Python` is just a marker, pyo3 allows retrieve it for native types, with lifetime restriction).
Though this is a really breaking change, I think it enhances our API ergonomics.