### PR TITLE
Remove PyArrayModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ We need your feedback. Don't hesitate to open [issues](https://github.com/termos
 
 Version
 --------
+- v0.4.0(Coming soon)
+  - Duplicate `PyArrayModule` and import Numpy API automatically
+
+- v0.3.1, v0.3.2
+  - Just update dependencies
+
 - v0.3.0
   - Breaking Change: Migrated to pyo3 from rust-cpython
   - Some api addition

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,16 +3,11 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyArray, IntoPyResult, PyArray, PyArrayModule};
+use numpy::{IntoPyArray, IntoPyResult, PyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
-fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    // You **must** write this statement for the PyArray type checker to work correctly
-    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    let _np = PyArrayModule::import(py)?;
-
+fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
     // immutable example
     fn axpy(a: f64, x: ArrayViewD<f64>, y: ArrayViewD<f64>) -> ArrayD<f64> {
         a * &x + &y
@@ -26,10 +21,9 @@ fn rust_ext(py: Python, m: &PyModule) -> PyResult<()> {
     // wrapper of `axpy`
     #[pyfn(m, "axpy")]
     fn axpy_py(py: Python, a: f64, x: &PyArray<f64>, y: &PyArray<f64>) -> PyResult<PyArray<f64>> {
-        let np = PyArrayModule::import(py)?;
         let x = x.as_array().into_pyresult("x must be f64 array")?;
         let y = y.as_array().into_pyresult("y must be f64 array")?;
-        Ok(axpy(a, x, y).into_pyarray(py, &np))
+        Ok(axpy(a, x, y).into_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`

--- a/src/array.rs
+++ b/src/array.rs
@@ -62,6 +62,11 @@ impl<T> PyArray<T> {
         self.as_ptr() as _
     }
 
+    pub fn to_owned(&self, py: Python) -> Self {
+        let obj = unsafe { PyObject::from_borrowed_ptr(py, self.as_ptr()) };
+        PyArray(obj, PhantomData)
+    }
+
     /// Constructs `PyArray` from raw python object without incrementing reference counts.
     pub unsafe fn from_owned_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> &Self {
         py.from_owned_ptr(ptr)

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -15,10 +15,9 @@ use super::*;
 /// # Example
 /// ```
 /// # extern crate pyo3; extern crate numpy; fn main() {
-/// use numpy::{PyArray, PyArrayModule, IntoPyArray};
+/// use numpy::{PyArray, IntoPyArray};
 /// let gil = pyo3::Python::acquire_gil();
-/// let np = PyArrayModule::import(gil.python()).unwrap();
-/// let py_array = vec![1, 2, 3].into_pyarray(gil.python(), &np);
+/// let py_array = vec![1, 2, 3].into_pyarray(gil.python());
 /// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
 /// # }
 /// ```

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -24,12 +24,12 @@ use super::*;
 /// ```
 pub trait IntoPyArray {
     type Item: TypeNum;
-    fn into_pyarray(self, Python) -> PyArray<Self::Item>;
+    fn into_pyarray(self, Python) -> &PyArray<Self::Item>;
 }
 
 impl<T: TypeNum> IntoPyArray for Box<[T]> {
     type Item = T;
-    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> &PyArray<Self::Item> {
         let dims = [self.len()];
         let ptr = Box::into_raw(self);
         unsafe { PyArray::new_(py, &dims, null_mut(), ptr as *mut c_void) }
@@ -38,7 +38,7 @@ impl<T: TypeNum> IntoPyArray for Box<[T]> {
 
 impl<T: TypeNum> IntoPyArray for Vec<T> {
     type Item = T;
-    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> &PyArray<Self::Item> {
         let dims = [self.len()];
         unsafe { PyArray::new_(py, &dims, null_mut(), into_raw(self)) }
     }
@@ -46,7 +46,7 @@ impl<T: TypeNum> IntoPyArray for Vec<T> {
 
 impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
     type Item = A;
-    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> &PyArray<Self::Item> {
         let dims: Vec<_> = self.shape().iter().cloned().collect();
         let mut strides: Vec<_> = self
             .strides()
@@ -65,7 +65,7 @@ macro_rules! array_impls {
         $(
             impl<T: TypeNum> IntoPyArray for [T; $N] {
                 type Item = T;
-                fn into_pyarray(self, py: Python) -> PyArray<T> {
+                fn into_pyarray(self, py: Python) -> &PyArray<T> {
                     let dims = [$N];
                     let ptr = Box::into_raw(Box::new(self));
                     unsafe {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -24,29 +24,29 @@ use super::*;
 /// ```
 pub trait IntoPyArray {
     type Item: TypeNum;
-    fn into_pyarray(self, Python, &PyArrayModule) -> PyArray<Self::Item>;
+    fn into_pyarray(self, Python) -> PyArray<Self::Item>;
 }
 
 impl<T: TypeNum> IntoPyArray for Box<[T]> {
     type Item = T;
-    fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
         let dims = [self.len()];
         let ptr = Box::into_raw(self);
-        unsafe { PyArray::new_(py, np, &dims, null_mut(), ptr as *mut c_void) }
+        unsafe { PyArray::new_(py, &dims, null_mut(), ptr as *mut c_void) }
     }
 }
 
 impl<T: TypeNum> IntoPyArray for Vec<T> {
     type Item = T;
-    fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
         let dims = [self.len()];
-        unsafe { PyArray::new_(py, np, &dims, null_mut(), into_raw(self)) }
+        unsafe { PyArray::new_(py, &dims, null_mut(), into_raw(self)) }
     }
 }
 
 impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
     type Item = A;
-    fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
         let dims: Vec<_> = self.shape().iter().cloned().collect();
         let mut strides: Vec<_> = self
             .strides()
@@ -55,7 +55,7 @@ impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
             .collect();
         unsafe {
             let data = into_raw(self.into_raw_vec());
-            PyArray::new_(py, np, &dims, strides.as_mut_ptr(), data)
+            PyArray::new_(py, &dims, strides.as_mut_ptr(), data)
         }
     }
 }
@@ -65,11 +65,11 @@ macro_rules! array_impls {
         $(
             impl<T: TypeNum> IntoPyArray for [T; $N] {
                 type Item = T;
-                fn into_pyarray(self, py: Python, np: &PyArrayModule) -> PyArray<T> {
+                fn into_pyarray(self, py: Python) -> PyArray<T> {
                     let dims = [$N];
                     let ptr = Box::into_raw(Box::new(self));
                     unsafe {
-                        PyArray::new_(py, np, &dims, null_mut(), ptr as *mut c_void)
+                        PyArray::new_(py, &dims, null_mut(), ptr as *mut c_void)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,5 +47,5 @@ pub mod types;
 pub use array::PyArray;
 pub use convert::IntoPyArray;
 pub use error::*;
-pub use npyffi::{PyArrayAPI, PyUFuncModule};
+pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,11 @@
 //! extern crate numpy;
 //! extern crate pyo3;
 //! use pyo3::prelude::Python;
-//! use numpy::{IntoPyArray, PyArray, PyArrayModule};
+//! use numpy::{IntoPyArray, PyArray};
 //! fn main() {
 //!     let gil = Python::acquire_gil();
 //!     let py = gil.python();
-//!     let np = PyArrayModule::import(py).unwrap();
-//!     let py_array = array![[1i64, 2], [3, 4]].into_pyarray(py, &np);
+//!     let py_array = array![[1i64, 2], [3, 4]].into_pyarray(py);
 //!     assert_eq!(
 //!         py_array.as_array().unwrap(),
 //!         array![[1i64, 2], [3, 4]].into_dyn(),
@@ -44,7 +43,7 @@ pub mod error;
 pub mod npyffi;
 pub mod types;
 
-pub use array::PyArray;
+pub use array::{get_array_module, PyArray};
 pub use convert::IntoPyArray;
 pub use error::*;
 pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 //!     );
 //! }
 //! ```
-
 #![feature(specialization)]
 
 #[macro_use]
@@ -48,5 +47,5 @@ pub mod types;
 pub use array::PyArray;
 pub use convert::IntoPyArray;
 pub use error::*;
-pub use npyffi::{PyArrayModule, PyUFuncModule};
+pub use npyffi::{PyArrayAPI, PyUFuncModule};
 pub use types::*;

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -1,8 +1,6 @@
 //! Low-Level binding for [Array API](https://docs.scipy.org/doc/numpy/reference/c-api.array.html)
 use libc::FILE;
-use pyo3::ffi;
-use pyo3::ffi::{PyObject, PyTypeObject};
-use pyo3::{ObjectProtocol, Python, ToPyPointer};
+use pyo3::ffi::{self, PyObject, PyTypeObject};
 use std::ops::Deref;
 use std::os::raw::*;
 use std::ptr;
@@ -10,7 +8,10 @@ use std::sync::{Once, ONCE_INIT};
 
 use npyffi::*;
 
-pub static PyArrayAPI: PyArrayAPI = PyArrayAPI {
+const MOD_NAME: &str = "numpy.core.multiarray";
+const CAPSULE_NAME: &str = "_ARRAY_API";
+
+pub static PY_ARRAY_API: PyArrayAPI = PyArrayAPI {
     __private_field: (),
 };
 
@@ -24,18 +25,8 @@ impl Deref for PyArrayAPI {
         static INIT_API: Once = ONCE_INIT;
         static mut ARRAY_API_CACHE: PyArrayAPI_Inner = PyArrayAPI_Inner(ptr::null());
         INIT_API.call_once(|| {
-            let gil = Python::acquire_gil();
-            let numpy = gil
-                .python()
-                .import("numpy.core.multiarray")
-                .expect("Failed to import numpy.core.multiarray");
-            let cupsule = numpy
-                .getattr("_ARRAY_API")
-                .expect("Failed to import numpy.core.multiarray._ARRAY_API");
             unsafe {
-                ARRAY_API_CACHE =
-                    PyArrayAPI_Inner(ffi::PyCapsule_GetPointer(cupsule.as_ptr(), ptr::null_mut())
-                        as *const *const c_void);
+                ARRAY_API_CACHE = PyArrayAPI_Inner(get_numpy_api(MOD_NAME, CAPSULE_NAME));
             };
         });
         unsafe { &ARRAY_API_CACHE }
@@ -45,276 +36,265 @@ impl Deref for PyArrayAPI {
 #[allow(non_camel_case_types)]
 #[doc(hidden)]
 pub struct PyArrayAPI_Inner(*const *const c_void);
-// Define Array APIs
-macro_rules! pyarray_api {
-    [ $offset:expr; $fname:ident ( $($arg:ident : $t:ty),* ) $( -> $ret:ty )* ] => {
-        #[allow(non_snake_case)]
-        pub unsafe fn $fname(&self, $($arg : $t), *) $( -> $ret )* {
-            let fptr = self.0.offset($offset)
-                               as (*const extern fn ($($arg : $t), *) $( -> $ret )* );
-            (*fptr)($($arg), *)
-        }
-    }
-}
 
 impl PyArrayAPI_Inner {
-    pyarray_api![0; PyArray_GetNDArrayCVersion() -> c_uint];
-    pyarray_api![40; PyArray_SetNumericOps(dict: *mut PyObject) -> c_int];
-    pyarray_api![41; PyArray_GetNumericOps() -> *mut PyObject];
-    pyarray_api![42; PyArray_INCREF(mp: *mut PyArrayObject) -> c_int];
-    pyarray_api![43; PyArray_XDECREF(mp: *mut PyArrayObject) -> c_int];
-    pyarray_api![44; PyArray_SetStringFunction(op: *mut PyObject, repr: c_int)];
-    pyarray_api![45; PyArray_DescrFromType(type_: c_int) -> *mut PyArray_Descr];
-    pyarray_api![46; PyArray_TypeObjectFromType(type_: c_int) -> *mut PyObject];
-    pyarray_api![47; PyArray_Zero(arr: *mut PyArrayObject) -> *mut c_char];
-    pyarray_api![48; PyArray_One(arr: *mut PyArrayObject) -> *mut c_char];
-    pyarray_api![49; PyArray_CastToType(arr: *mut PyArrayObject, dtype: *mut PyArray_Descr, is_f_order: c_int) -> *mut PyObject];
-    pyarray_api![50; PyArray_CastTo(out: *mut PyArrayObject, mp: *mut PyArrayObject) -> c_int];
-    pyarray_api![51; PyArray_CastAnyTo(out: *mut PyArrayObject, mp: *mut PyArrayObject) -> c_int];
-    pyarray_api![52; PyArray_CanCastSafely(fromtype: c_int, totype: c_int) -> c_int];
-    pyarray_api![53; PyArray_CanCastTo(from: *mut PyArray_Descr, to: *mut PyArray_Descr) -> npy_bool];
-    pyarray_api![54; PyArray_ObjectType(op: *mut PyObject, minimum_type: c_int) -> c_int];
-    pyarray_api![55; PyArray_DescrFromObject(op: *mut PyObject, mintype: *mut PyArray_Descr) -> *mut PyArray_Descr];
-    pyarray_api![56; PyArray_ConvertToCommonType(op: *mut PyObject, retn: *mut c_int) -> *mut *mut PyArrayObject];
-    pyarray_api![57; PyArray_DescrFromScalar(sc: *mut PyObject) -> *mut PyArray_Descr];
-    pyarray_api![58; PyArray_DescrFromTypeObject(type_: *mut PyObject) -> *mut PyArray_Descr];
-    pyarray_api![59; PyArray_Size(op: *mut PyObject) -> npy_intp];
-    pyarray_api![60; PyArray_Scalar(data: *mut c_void, descr: *mut PyArray_Descr, base: *mut PyObject) -> *mut PyObject];
-    pyarray_api![61; PyArray_FromScalar(scalar: *mut PyObject, outcode: *mut PyArray_Descr) -> *mut PyObject];
-    pyarray_api![62; PyArray_ScalarAsCtype(scalar: *mut PyObject, ctypeptr: *mut c_void)];
-    pyarray_api![63; PyArray_CastScalarToCtype(scalar: *mut PyObject, ctypeptr: *mut c_void, outcode: *mut PyArray_Descr) -> c_int];
-    pyarray_api![64; PyArray_CastScalarDirect(scalar: *mut PyObject, indescr: *mut PyArray_Descr, ctypeptr: *mut c_void, outtype: c_int) -> c_int];
-    pyarray_api![65; PyArray_ScalarFromObject(object: *mut PyObject) -> *mut PyObject];
-    pyarray_api![66; PyArray_GetCastFunc(descr: *mut PyArray_Descr, type_num: c_int) -> PyArray_VectorUnaryFunc];
-    pyarray_api![67; PyArray_FromDims(nd: c_int, d: *mut c_int, type_: c_int) -> *mut PyObject];
-    pyarray_api![68; PyArray_FromDimsAndDataAndDescr(nd: c_int, d: *mut c_int, descr: *mut PyArray_Descr, data: *mut c_char) -> *mut PyObject];
-    pyarray_api![69; PyArray_FromAny(op: *mut PyObject, newtype: *mut PyArray_Descr, min_depth: c_int, max_depth: c_int, flags: c_int, context: *mut PyObject) -> *mut PyObject];
-    pyarray_api![70; PyArray_EnsureArray(op: *mut PyObject) -> *mut PyObject];
-    pyarray_api![71; PyArray_EnsureAnyArray(op: *mut PyObject) -> *mut PyObject];
-    pyarray_api![72; PyArray_FromFile(fp: *mut FILE, dtype: *mut PyArray_Descr, num: npy_intp, sep: *mut c_char) -> *mut PyObject];
-    pyarray_api![73; PyArray_FromString(data: *mut c_char, slen: npy_intp, dtype: *mut PyArray_Descr, num: npy_intp, sep: *mut c_char) -> *mut PyObject];
-    pyarray_api![74; PyArray_FromBuffer(buf: *mut PyObject, type_: *mut PyArray_Descr, count: npy_intp, offset: npy_intp) -> *mut PyObject];
-    pyarray_api![75; PyArray_FromIter(obj: *mut PyObject, dtype: *mut PyArray_Descr, count: npy_intp) -> *mut PyObject];
-    pyarray_api![76; PyArray_Return(mp: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![77; PyArray_GetField(self_: *mut PyArrayObject, typed: *mut PyArray_Descr, offset: c_int) -> *mut PyObject];
-    pyarray_api![78; PyArray_SetField(self_: *mut PyArrayObject, dtype: *mut PyArray_Descr, offset: c_int, val: *mut PyObject) -> c_int];
-    pyarray_api![79; PyArray_Byteswap(self_: *mut PyArrayObject, inplace: npy_bool) -> *mut PyObject];
-    pyarray_api![80; PyArray_Resize(self_: *mut PyArrayObject, newshape: *mut PyArray_Dims, refcheck: c_int, order: NPY_ORDER) -> *mut PyObject];
-    pyarray_api![81; PyArray_MoveInto(dst: *mut PyArrayObject, src: *mut PyArrayObject) -> c_int];
-    pyarray_api![82; PyArray_CopyInto(dst: *mut PyArrayObject, src: *mut PyArrayObject) -> c_int];
-    pyarray_api![83; PyArray_CopyAnyInto(dst: *mut PyArrayObject, src: *mut PyArrayObject) -> c_int];
-    pyarray_api![84; PyArray_CopyObject(dest: *mut PyArrayObject, src_object: *mut PyObject) -> c_int];
-    pyarray_api![85; PyArray_NewCopy(obj: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
-    pyarray_api![86; PyArray_ToList(self_: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![87; PyArray_ToString(self_: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
-    pyarray_api![88; PyArray_ToFile(self_: *mut PyArrayObject, fp: *mut FILE, sep: *mut c_char, format: *mut c_char) -> c_int];
-    pyarray_api![89; PyArray_Dump(self_: *mut PyObject, file: *mut PyObject, protocol: c_int) -> c_int];
-    pyarray_api![90; PyArray_Dumps(self_: *mut PyObject, protocol: c_int) -> *mut PyObject];
-    pyarray_api![91; PyArray_ValidType(type_: c_int) -> c_int];
-    pyarray_api![92; PyArray_UpdateFlags(ret: *mut PyArrayObject, flagmask: c_int)];
-    pyarray_api![93; PyArray_New(subtype: *mut PyTypeObject, nd: c_int, dims: *mut npy_intp, type_num: c_int, strides: *mut npy_intp, data: *mut c_void, itemsize: c_int, flags: c_int, obj: *mut PyObject) -> *mut PyObject];
-    pyarray_api![94; PyArray_NewFromDescr(subtype: *mut PyTypeObject, descr: *mut PyArray_Descr, nd: c_int, dims: *mut npy_intp, strides: *mut npy_intp, data: *mut c_void, flags: c_int, obj: *mut PyObject) -> *mut PyObject];
-    pyarray_api![95; PyArray_DescrNew(base: *mut PyArray_Descr) -> *mut PyArray_Descr];
-    pyarray_api![96; PyArray_DescrNewFromType(type_num: c_int) -> *mut PyArray_Descr];
-    pyarray_api![97; PyArray_GetPriority(obj: *mut PyObject, default_: f64) -> f64];
-    pyarray_api![98; PyArray_IterNew(obj: *mut PyObject) -> *mut PyObject];
-    // pyarray_api![99; PyArray_MultiIterNew(n: c_int, ...) -> *mut PyObject];
-    pyarray_api![100; PyArray_PyIntAsInt(o: *mut PyObject) -> c_int];
-    pyarray_api![101; PyArray_PyIntAsIntp(o: *mut PyObject) -> npy_intp];
-    pyarray_api![102; PyArray_Broadcast(mit: *mut PyArrayMultiIterObject) -> c_int];
-    pyarray_api![103; PyArray_FillObjectArray(arr: *mut PyArrayObject, obj: *mut PyObject)];
-    pyarray_api![104; PyArray_FillWithScalar(arr: *mut PyArrayObject, obj: *mut PyObject) -> c_int];
-    pyarray_api![105; PyArray_CheckStrides(elsize: c_int, nd: c_int, numbytes: npy_intp, offset: npy_intp, dims: *mut npy_intp, newstrides: *mut npy_intp) -> npy_bool];
-    pyarray_api![106; PyArray_DescrNewByteorder(self_: *mut PyArray_Descr, newendian: c_char) -> *mut PyArray_Descr];
-    pyarray_api![107; PyArray_IterAllButAxis(obj: *mut PyObject, inaxis: *mut c_int) -> *mut PyObject];
-    pyarray_api![108; PyArray_CheckFromAny(op: *mut PyObject, descr: *mut PyArray_Descr, min_depth: c_int, max_depth: c_int, requires: c_int, context: *mut PyObject) -> *mut PyObject];
-    pyarray_api![109; PyArray_FromArray(arr: *mut PyArrayObject, newtype: *mut PyArray_Descr, flags: c_int) -> *mut PyObject];
-    pyarray_api![110; PyArray_FromInterface(origin: *mut PyObject) -> *mut PyObject];
-    pyarray_api![111; PyArray_FromStructInterface(input: *mut PyObject) -> *mut PyObject];
-    pyarray_api![112; PyArray_FromArrayAttr(op: *mut PyObject, typecode: *mut PyArray_Descr, context: *mut PyObject) -> *mut PyObject];
-    pyarray_api![113; PyArray_ScalarKind(typenum: c_int, arr: *mut *mut PyArrayObject) -> NPY_SCALARKIND];
-    pyarray_api![114; PyArray_CanCoerceScalar(thistype: c_int, neededtype: c_int, scalar: NPY_SCALARKIND) -> c_int];
-    pyarray_api![115; PyArray_NewFlagsObject(obj: *mut PyObject) -> *mut PyObject];
-    pyarray_api![116; PyArray_CanCastScalar(from: *mut PyTypeObject, to: *mut PyTypeObject) -> npy_bool];
-    pyarray_api![117; PyArray_CompareUCS4(s1: *mut npy_ucs4, s2: *mut npy_ucs4, len: usize) -> c_int];
-    pyarray_api![118; PyArray_RemoveSmallest(multi: *mut PyArrayMultiIterObject) -> c_int];
-    pyarray_api![119; PyArray_ElementStrides(obj: *mut PyObject) -> c_int];
-    pyarray_api![120; PyArray_Item_INCREF(data: *mut c_char, descr: *mut PyArray_Descr)];
-    pyarray_api![121; PyArray_Item_XDECREF(data: *mut c_char, descr: *mut PyArray_Descr)];
-    pyarray_api![122; PyArray_FieldNames(fields: *mut PyObject) -> *mut PyObject];
-    pyarray_api![123; PyArray_Transpose(ap: *mut PyArrayObject, permute: *mut PyArray_Dims) -> *mut PyObject];
-    pyarray_api![124; PyArray_TakeFrom(self0: *mut PyArrayObject, indices0: *mut PyObject, axis: c_int, out: *mut PyArrayObject, clipmode: NPY_CLIPMODE) -> *mut PyObject];
-    pyarray_api![125; PyArray_PutTo(self_: *mut PyArrayObject, values0: *mut PyObject, indices0: *mut PyObject, clipmode: NPY_CLIPMODE) -> *mut PyObject];
-    pyarray_api![126; PyArray_PutMask(self_: *mut PyArrayObject, values0: *mut PyObject, mask0: *mut PyObject) -> *mut PyObject];
-    pyarray_api![127; PyArray_Repeat(aop: *mut PyArrayObject, op: *mut PyObject, axis: c_int) -> *mut PyObject];
-    pyarray_api![128; PyArray_Choose(ip: *mut PyArrayObject, op: *mut PyObject, out: *mut PyArrayObject, clipmode: NPY_CLIPMODE) -> *mut PyObject];
-    pyarray_api![129; PyArray_Sort(op: *mut PyArrayObject, axis: c_int, which: NPY_SORTKIND) -> c_int];
-    pyarray_api![130; PyArray_ArgSort(op: *mut PyArrayObject, axis: c_int, which: NPY_SORTKIND) -> *mut PyObject];
-    pyarray_api![131; PyArray_SearchSorted(op1: *mut PyArrayObject, op2: *mut PyObject, side: NPY_SEARCHSIDE, perm: *mut PyObject) -> *mut PyObject];
-    pyarray_api![132; PyArray_ArgMax(op: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![133; PyArray_ArgMin(op: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![134; PyArray_Reshape(self_: *mut PyArrayObject, shape: *mut PyObject) -> *mut PyObject];
-    pyarray_api![135; PyArray_Newshape(self_: *mut PyArrayObject, newdims: *mut PyArray_Dims, order: NPY_ORDER) -> *mut PyObject];
-    pyarray_api![136; PyArray_Squeeze(self_: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![137; PyArray_View(self_: *mut PyArrayObject, type_: *mut PyArray_Descr, pytype: *mut PyTypeObject) -> *mut PyObject];
-    pyarray_api![138; PyArray_SwapAxes(ap: *mut PyArrayObject, a1: c_int, a2: c_int) -> *mut PyObject];
-    pyarray_api![139; PyArray_Max(ap: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![140; PyArray_Min(ap: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![141; PyArray_Ptp(ap: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![142; PyArray_Mean(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![143; PyArray_Trace(self_: *mut PyArrayObject, offset: c_int, axis1: c_int, axis2: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![144; PyArray_Diagonal(self_: *mut PyArrayObject, offset: c_int, axis1: c_int, axis2: c_int) -> *mut PyObject];
-    pyarray_api![145; PyArray_Clip(self_: *mut PyArrayObject, min: *mut PyObject, max: *mut PyObject, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![146; PyArray_Conjugate(self_: *mut PyArrayObject, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![147; PyArray_Nonzero(self_: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![148; PyArray_Std(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject, variance: c_int) -> *mut PyObject];
-    pyarray_api![149; PyArray_Sum(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![150; PyArray_CumSum(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![151; PyArray_Prod(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![152; PyArray_CumProd(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![153; PyArray_All(self_: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![154; PyArray_Any(self_: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![155; PyArray_Compress(self_: *mut PyArrayObject, condition: *mut PyObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![156; PyArray_Flatten(a: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
-    pyarray_api![157; PyArray_Ravel(arr: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
-    pyarray_api![158; PyArray_MultiplyList(l1: *mut npy_intp, n: c_int) -> npy_intp];
-    pyarray_api![159; PyArray_MultiplyIntList(l1: *mut c_int, n: c_int) -> c_int];
-    pyarray_api![160; PyArray_GetPtr(obj: *mut PyArrayObject, ind: *mut npy_intp) -> *mut c_void];
-    pyarray_api![161; PyArray_CompareLists(l1: *mut npy_intp, l2: *mut npy_intp, n: c_int) -> c_int];
-    pyarray_api![162; PyArray_AsCArray(op: *mut *mut PyObject, ptr: *mut c_void, dims: *mut npy_intp, nd: c_int, typedescr: *mut PyArray_Descr) -> c_int];
-    pyarray_api![163; PyArray_As1D(op: *mut *mut PyObject, ptr: *mut *mut c_char, d1: *mut c_int, typecode: c_int) -> c_int];
-    pyarray_api![164; PyArray_As2D(op: *mut *mut PyObject, ptr: *mut *mut *mut c_char, d1: *mut c_int, d2: *mut c_int, typecode: c_int) -> c_int];
-    pyarray_api![165; PyArray_Free(op: *mut PyObject, ptr: *mut c_void) -> c_int];
-    pyarray_api![166; PyArray_Converter(object: *mut PyObject, address: *mut *mut PyObject) -> c_int];
-    pyarray_api![167; PyArray_IntpFromSequence(seq: *mut PyObject, vals: *mut npy_intp, maxvals: c_int) -> c_int];
-    pyarray_api![168; PyArray_Concatenate(op: *mut PyObject, axis: c_int) -> *mut PyObject];
-    pyarray_api![169; PyArray_InnerProduct(op1: *mut PyObject, op2: *mut PyObject) -> *mut PyObject];
-    pyarray_api![170; PyArray_MatrixProduct(op1: *mut PyObject, op2: *mut PyObject) -> *mut PyObject];
-    pyarray_api![171; PyArray_CopyAndTranspose(op: *mut PyObject) -> *mut PyObject];
-    pyarray_api![172; PyArray_Correlate(op1: *mut PyObject, op2: *mut PyObject, mode: c_int) -> *mut PyObject];
-    pyarray_api![173; PyArray_TypestrConvert(itemsize: c_int, gentype: c_int) -> c_int];
-    pyarray_api![174; PyArray_DescrConverter(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
-    pyarray_api![175; PyArray_DescrConverter2(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
-    pyarray_api![176; PyArray_IntpConverter(obj: *mut PyObject, seq: *mut PyArray_Dims) -> c_int];
-    pyarray_api![177; PyArray_BufferConverter(obj: *mut PyObject, buf: *mut PyArray_Chunk) -> c_int];
-    pyarray_api![178; PyArray_AxisConverter(obj: *mut PyObject, axis: *mut c_int) -> c_int];
-    pyarray_api![179; PyArray_BoolConverter(object: *mut PyObject, val: *mut npy_bool) -> c_int];
-    pyarray_api![180; PyArray_ByteorderConverter(obj: *mut PyObject, endian: *mut c_char) -> c_int];
-    pyarray_api![181; PyArray_OrderConverter(object: *mut PyObject, val: *mut NPY_ORDER) -> c_int];
-    pyarray_api![182; PyArray_EquivTypes(type1: *mut PyArray_Descr, type2: *mut PyArray_Descr) -> c_uchar];
-    pyarray_api![183; PyArray_Zeros(nd: c_int, dims: *mut npy_intp, type_: *mut PyArray_Descr, is_f_order: c_int) -> *mut PyObject];
-    pyarray_api![184; PyArray_Empty(nd: c_int, dims: *mut npy_intp, type_: *mut PyArray_Descr, is_f_order: c_int) -> *mut PyObject];
-    pyarray_api![185; PyArray_Where(condition: *mut PyObject, x: *mut PyObject, y: *mut PyObject) -> *mut PyObject];
-    pyarray_api![186; PyArray_Arange(start: f64, stop: f64, step: f64, type_num: c_int) -> *mut PyObject];
-    pyarray_api![187; PyArray_ArangeObj(start: *mut PyObject, stop: *mut PyObject, step: *mut PyObject, dtype: *mut PyArray_Descr) -> *mut PyObject];
-    pyarray_api![188; PyArray_SortkindConverter(obj: *mut PyObject, sortkind: *mut NPY_SORTKIND) -> c_int];
-    pyarray_api![189; PyArray_LexSort(sort_keys: *mut PyObject, axis: c_int) -> *mut PyObject];
-    pyarray_api![190; PyArray_Round(a: *mut PyArrayObject, decimals: c_int, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![191; PyArray_EquivTypenums(typenum1: c_int, typenum2: c_int) -> c_uchar];
-    pyarray_api![192; PyArray_RegisterDataType(descr: *mut PyArray_Descr) -> c_int];
-    pyarray_api![193; PyArray_RegisterCastFunc(descr: *mut PyArray_Descr, totype: c_int, castfunc: PyArray_VectorUnaryFunc) -> c_int];
-    pyarray_api![194; PyArray_RegisterCanCast(descr: *mut PyArray_Descr, totype: c_int, scalar: NPY_SCALARKIND) -> c_int];
-    pyarray_api![195; PyArray_InitArrFuncs(f: *mut PyArray_ArrFuncs)];
-    pyarray_api![196; PyArray_IntTupleFromIntp(len: c_int, vals: *mut npy_intp) -> *mut PyObject];
-    pyarray_api![197; PyArray_TypeNumFromName(str: *mut c_char) -> c_int];
-    pyarray_api![198; PyArray_ClipmodeConverter(object: *mut PyObject, val: *mut NPY_CLIPMODE) -> c_int];
-    pyarray_api![199; PyArray_OutputConverter(object: *mut PyObject, address: *mut *mut PyArrayObject) -> c_int];
-    pyarray_api![200; PyArray_BroadcastToShape(obj: *mut PyObject, dims: *mut npy_intp, nd: c_int) -> *mut PyObject];
-    pyarray_api![201; _PyArray_SigintHandler(signum: c_int)];
-    pyarray_api![202; _PyArray_GetSigintBuf() -> *mut c_void];
-    pyarray_api![203; PyArray_DescrAlignConverter(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
-    pyarray_api![204; PyArray_DescrAlignConverter2(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
-    pyarray_api![205; PyArray_SearchsideConverter(obj: *mut PyObject, addr: *mut c_void) -> c_int];
-    pyarray_api![206; PyArray_CheckAxis(arr: *mut PyArrayObject, axis: *mut c_int, flags: c_int) -> *mut PyObject];
-    pyarray_api![207; PyArray_OverflowMultiplyList(l1: *mut npy_intp, n: c_int) -> npy_intp];
-    pyarray_api![208; PyArray_CompareString(s1: *mut c_char, s2: *mut c_char, len: usize) -> c_int];
-    // pyarray_api![209; PyArray_MultiIterFromObjects(mps: *mut *mut PyObject, n: c_int, nadd: c_int, ...) -> *mut PyObject];
-    pyarray_api![210; PyArray_GetEndianness() -> c_int];
-    pyarray_api![211; PyArray_GetNDArrayCFeatureVersion() -> c_uint];
-    pyarray_api![212; PyArray_Correlate2(op1: *mut PyObject, op2: *mut PyObject, mode: c_int) -> *mut PyObject];
-    pyarray_api![213; PyArray_NeighborhoodIterNew(x: *mut PyArrayIterObject, bounds: *mut npy_intp, mode: c_int, fill: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![219; PyArray_SetDatetimeParseFunction(op: *mut PyObject)];
-    pyarray_api![220; PyArray_DatetimeToDatetimeStruct(val: npy_datetime, fr: NPY_DATETIMEUNIT, result: *mut npy_datetimestruct)];
-    pyarray_api![221; PyArray_TimedeltaToTimedeltaStruct(val: npy_timedelta, fr: NPY_DATETIMEUNIT, result: *mut npy_timedeltastruct)];
-    pyarray_api![222; PyArray_DatetimeStructToDatetime(fr: NPY_DATETIMEUNIT, d: *mut npy_datetimestruct) -> npy_datetime];
-    pyarray_api![223; PyArray_TimedeltaStructToTimedelta(fr: NPY_DATETIMEUNIT, d: *mut npy_timedeltastruct) -> npy_datetime];
-    pyarray_api![224; NpyIter_New(op: *mut PyArrayObject, flags: npy_uint32, order: NPY_ORDER, casting: NPY_CASTING, dtype: *mut PyArray_Descr) -> *mut NpyIter];
-    pyarray_api![225; NpyIter_MultiNew(nop: c_int, op_in: *mut *mut PyArrayObject, flags: npy_uint32, order: NPY_ORDER, casting: NPY_CASTING, op_flags: *mut npy_uint32, op_request_dtypes: *mut *mut PyArray_Descr) -> *mut NpyIter];
-    pyarray_api![226; NpyIter_AdvancedNew(nop: c_int, op_in: *mut *mut PyArrayObject, flags: npy_uint32, order: NPY_ORDER, casting: NPY_CASTING, op_flags: *mut npy_uint32, op_request_dtypes: *mut *mut PyArray_Descr, oa_ndim: c_int, op_axes: *mut *mut c_int, itershape: *mut npy_intp, buffersize: npy_intp) -> *mut NpyIter];
-    pyarray_api![227; NpyIter_Copy(iter: *mut NpyIter) -> *mut NpyIter];
-    pyarray_api![228; NpyIter_Deallocate(iter: *mut NpyIter) -> c_int];
-    pyarray_api![229; NpyIter_HasDelayedBufAlloc(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![230; NpyIter_HasExternalLoop(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![231; NpyIter_EnableExternalLoop(iter: *mut NpyIter) -> c_int];
-    pyarray_api![232; NpyIter_GetInnerStrideArray(iter: *mut NpyIter) -> *mut npy_intp];
-    pyarray_api![233; NpyIter_GetInnerLoopSizePtr(iter: *mut NpyIter) -> *mut npy_intp];
-    pyarray_api![234; NpyIter_Reset(iter: *mut NpyIter, errmsg: *mut *mut c_char) -> c_int];
-    pyarray_api![235; NpyIter_ResetBasePointers(iter: *mut NpyIter, baseptrs: *mut *mut c_char, errmsg: *mut *mut c_char) -> c_int];
-    pyarray_api![236; NpyIter_ResetToIterIndexRange(iter: *mut NpyIter, istart: npy_intp, iend: npy_intp, errmsg: *mut *mut c_char) -> c_int];
-    pyarray_api![237; NpyIter_GetNDim(iter: *mut NpyIter) -> c_int];
-    pyarray_api![238; NpyIter_GetNOp(iter: *mut NpyIter) -> c_int];
-    pyarray_api![239; NpyIter_GetIterNext(iter: *mut NpyIter, errmsg: *mut *mut c_char) -> NpyIter_IterNextFunc];
-    pyarray_api![240; NpyIter_GetIterSize(iter: *mut NpyIter) -> npy_intp];
-    pyarray_api![241; NpyIter_GetIterIndexRange(iter: *mut NpyIter, istart: *mut npy_intp, iend: *mut npy_intp)];
-    pyarray_api![242; NpyIter_GetIterIndex(iter: *mut NpyIter) -> npy_intp];
-    pyarray_api![243; NpyIter_GotoIterIndex(iter: *mut NpyIter, iterindex: npy_intp) -> c_int];
-    pyarray_api![244; NpyIter_HasMultiIndex(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![245; NpyIter_GetShape(iter: *mut NpyIter, outshape: *mut npy_intp) -> c_int];
-    pyarray_api![246; NpyIter_GetGetMultiIndex(iter: *mut NpyIter, errmsg: *mut *mut c_char) -> NpyIter_GetMultiIndexFunc];
-    pyarray_api![247; NpyIter_GotoMultiIndex(iter: *mut NpyIter, multi_index: *mut npy_intp) -> c_int];
-    pyarray_api![248; NpyIter_RemoveMultiIndex(iter: *mut NpyIter) -> c_int];
-    pyarray_api![249; NpyIter_HasIndex(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![250; NpyIter_IsBuffered(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![251; NpyIter_IsGrowInner(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![252; NpyIter_GetBufferSize(iter: *mut NpyIter) -> npy_intp];
-    pyarray_api![253; NpyIter_GetIndexPtr(iter: *mut NpyIter) -> *mut npy_intp];
-    pyarray_api![254; NpyIter_GotoIndex(iter: *mut NpyIter, flat_index: npy_intp) -> c_int];
-    pyarray_api![255; NpyIter_GetDataPtrArray(iter: *mut NpyIter) -> *mut *mut c_char];
-    pyarray_api![256; NpyIter_GetDescrArray(iter: *mut NpyIter) -> *mut *mut PyArray_Descr];
-    pyarray_api![257; NpyIter_GetOperandArray(iter: *mut NpyIter) -> *mut *mut PyArrayObject];
-    pyarray_api![258; NpyIter_GetIterView(iter: *mut NpyIter, i: npy_intp) -> *mut PyArrayObject];
-    pyarray_api![259; NpyIter_GetReadFlags(iter: *mut NpyIter, outreadflags: *mut c_char)];
-    pyarray_api![260; NpyIter_GetWriteFlags(iter: *mut NpyIter, outwriteflags: *mut c_char)];
-    pyarray_api![261; NpyIter_DebugPrint(iter: *mut NpyIter)];
-    pyarray_api![262; NpyIter_IterationNeedsAPI(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![263; NpyIter_GetInnerFixedStrideArray(iter: *mut NpyIter, out_strides: *mut npy_intp)];
-    pyarray_api![264; NpyIter_RemoveAxis(iter: *mut NpyIter, axis: c_int) -> c_int];
-    pyarray_api![265; NpyIter_GetAxisStrideArray(iter: *mut NpyIter, axis: c_int) -> *mut npy_intp];
-    pyarray_api![266; NpyIter_RequiresBuffering(iter: *mut NpyIter) -> npy_bool];
-    pyarray_api![267; NpyIter_GetInitialDataPtrArray(iter: *mut NpyIter) -> *mut *mut c_char];
-    pyarray_api![268; NpyIter_CreateCompatibleStrides(iter: *mut NpyIter, itemsize: npy_intp, outstrides: *mut npy_intp) -> c_int];
-    pyarray_api![269; PyArray_CastingConverter(obj: *mut PyObject, casting: *mut NPY_CASTING) -> c_int];
-    pyarray_api![270; PyArray_CountNonzero(self_: *mut PyArrayObject) -> npy_intp];
-    pyarray_api![271; PyArray_PromoteTypes(type1: *mut PyArray_Descr, type2: *mut PyArray_Descr) -> *mut PyArray_Descr];
-    pyarray_api![272; PyArray_MinScalarType(arr: *mut PyArrayObject) -> *mut PyArray_Descr];
-    pyarray_api![273; PyArray_ResultType(narrs: npy_intp, arr: *mut *mut PyArrayObject, ndtypes: npy_intp, dtypes: *mut *mut PyArray_Descr) -> *mut PyArray_Descr];
-    pyarray_api![274; PyArray_CanCastArrayTo(arr: *mut PyArrayObject, to: *mut PyArray_Descr, casting: NPY_CASTING) -> npy_bool];
-    pyarray_api![275; PyArray_CanCastTypeTo(from: *mut PyArray_Descr, to: *mut PyArray_Descr, casting: NPY_CASTING) -> npy_bool];
-    pyarray_api![276; PyArray_EinsteinSum(subscripts: *mut c_char, nop: npy_intp, op_in: *mut *mut PyArrayObject, dtype: *mut PyArray_Descr, order: NPY_ORDER, casting: NPY_CASTING, out: *mut PyArrayObject) -> *mut PyArrayObject];
-    pyarray_api![277; PyArray_NewLikeArray(prototype: *mut PyArrayObject, order: NPY_ORDER, dtype: *mut PyArray_Descr, subok: c_int) -> *mut PyObject];
-    pyarray_api![278; PyArray_GetArrayParamsFromObject(op: *mut PyObject, requested_dtype: *mut PyArray_Descr, writeable: npy_bool, out_dtype: *mut *mut PyArray_Descr, out_ndim: *mut c_int, out_dims: *mut npy_intp, out_arr: *mut *mut PyArrayObject, context: *mut PyObject) -> c_int];
-    pyarray_api![279; PyArray_ConvertClipmodeSequence(object: *mut PyObject, modes: *mut NPY_CLIPMODE, n: c_int) -> c_int];
-    pyarray_api![280; PyArray_MatrixProduct2(op1: *mut PyObject, op2: *mut PyObject, out: *mut PyArrayObject) -> *mut PyObject];
-    pyarray_api![281; NpyIter_IsFirstVisit(iter: *mut NpyIter, iop: c_int) -> npy_bool];
-    pyarray_api![282; PyArray_SetBaseObject(arr: *mut PyArrayObject, obj: *mut PyObject) -> c_int];
-    pyarray_api![283; PyArray_CreateSortedStridePerm(ndim: c_int, strides: *mut npy_intp, out_strideperm: *mut npy_stride_sort_item)];
-    pyarray_api![284; PyArray_RemoveAxesInPlace(arr: *mut PyArrayObject, flags: *mut npy_bool)];
-    pyarray_api![285; PyArray_DebugPrint(obj: *mut PyArrayObject)];
-    pyarray_api![286; PyArray_FailUnlessWriteable(obj: *mut PyArrayObject, name: *const c_char) -> c_int];
-    pyarray_api![287; PyArray_SetUpdateIfCopyBase(arr: *mut PyArrayObject, base: *mut PyArrayObject) -> c_int];
-    pyarray_api![288; PyDataMem_NEW(size: usize) -> *mut c_void];
-    pyarray_api![289; PyDataMem_FREE(ptr: *mut c_void)];
-    pyarray_api![290; PyDataMem_RENEW(ptr: *mut c_void, size: usize) -> *mut c_void];
-    pyarray_api![291; PyDataMem_SetEventHook(newhook: PyDataMem_EventHookFunc, user_data: *mut c_void, old_data: *mut *mut c_void) -> PyDataMem_EventHookFunc];
-    pyarray_api![293; PyArray_MapIterSwapAxes(mit: *mut PyArrayMapIterObject, ret: *mut *mut PyArrayObject, getmap: c_int)];
-    pyarray_api![294; PyArray_MapIterArray(a: *mut PyArrayObject, index: *mut PyObject) -> *mut PyObject];
-    pyarray_api![295; PyArray_MapIterNext(mit: *mut PyArrayMapIterObject)];
-    pyarray_api![296; PyArray_Partition(op: *mut PyArrayObject, ktharray: *mut PyArrayObject, axis: c_int, which: NPY_SELECTKIND) -> c_int];
-    pyarray_api![297; PyArray_ArgPartition(op: *mut PyArrayObject, ktharray: *mut PyArrayObject, axis: c_int, which: NPY_SELECTKIND) -> *mut PyObject];
-    pyarray_api![298; PyArray_SelectkindConverter(obj: *mut PyObject, selectkind: *mut NPY_SELECTKIND) -> c_int];
-    pyarray_api![299; PyDataMem_NEW_ZEROED(size: usize, elsize: usize) -> *mut c_void];
-    pyarray_api![300; PyArray_CheckAnyScalarExact(obj: *mut PyObject) -> c_int];
-    pyarray_api![301; PyArray_MapIterArrayCopyIfOverlap(a: *mut PyArrayObject, index: *mut PyObject, copy_if_overlap: c_int, extra_op: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![0; PyArray_GetNDArrayCVersion() -> c_uint];
+    impl_api![40; PyArray_SetNumericOps(dict: *mut PyObject) -> c_int];
+    impl_api![41; PyArray_GetNumericOps() -> *mut PyObject];
+    impl_api![42; PyArray_INCREF(mp: *mut PyArrayObject) -> c_int];
+    impl_api![43; PyArray_XDECREF(mp: *mut PyArrayObject) -> c_int];
+    impl_api![44; PyArray_SetStringFunction(op: *mut PyObject, repr: c_int)];
+    impl_api![45; PyArray_DescrFromType(type_: c_int) -> *mut PyArray_Descr];
+    impl_api![46; PyArray_TypeObjectFromType(type_: c_int) -> *mut PyObject];
+    impl_api![47; PyArray_Zero(arr: *mut PyArrayObject) -> *mut c_char];
+    impl_api![48; PyArray_One(arr: *mut PyArrayObject) -> *mut c_char];
+    impl_api![49; PyArray_CastToType(arr: *mut PyArrayObject, dtype: *mut PyArray_Descr, is_f_order: c_int) -> *mut PyObject];
+    impl_api![50; PyArray_CastTo(out: *mut PyArrayObject, mp: *mut PyArrayObject) -> c_int];
+    impl_api![51; PyArray_CastAnyTo(out: *mut PyArrayObject, mp: *mut PyArrayObject) -> c_int];
+    impl_api![52; PyArray_CanCastSafely(fromtype: c_int, totype: c_int) -> c_int];
+    impl_api![53; PyArray_CanCastTo(from: *mut PyArray_Descr, to: *mut PyArray_Descr) -> npy_bool];
+    impl_api![54; PyArray_ObjectType(op: *mut PyObject, minimum_type: c_int) -> c_int];
+    impl_api![55; PyArray_DescrFromObject(op: *mut PyObject, mintype: *mut PyArray_Descr) -> *mut PyArray_Descr];
+    impl_api![56; PyArray_ConvertToCommonType(op: *mut PyObject, retn: *mut c_int) -> *mut *mut PyArrayObject];
+    impl_api![57; PyArray_DescrFromScalar(sc: *mut PyObject) -> *mut PyArray_Descr];
+    impl_api![58; PyArray_DescrFromTypeObject(type_: *mut PyObject) -> *mut PyArray_Descr];
+    impl_api![59; PyArray_Size(op: *mut PyObject) -> npy_intp];
+    impl_api![60; PyArray_Scalar(data: *mut c_void, descr: *mut PyArray_Descr, base: *mut PyObject) -> *mut PyObject];
+    impl_api![61; PyArray_FromScalar(scalar: *mut PyObject, outcode: *mut PyArray_Descr) -> *mut PyObject];
+    impl_api![62; PyArray_ScalarAsCtype(scalar: *mut PyObject, ctypeptr: *mut c_void)];
+    impl_api![63; PyArray_CastScalarToCtype(scalar: *mut PyObject, ctypeptr: *mut c_void, outcode: *mut PyArray_Descr) -> c_int];
+    impl_api![64; PyArray_CastScalarDirect(scalar: *mut PyObject, indescr: *mut PyArray_Descr, ctypeptr: *mut c_void, outtype: c_int) -> c_int];
+    impl_api![65; PyArray_ScalarFromObject(object: *mut PyObject) -> *mut PyObject];
+    impl_api![66; PyArray_GetCastFunc(descr: *mut PyArray_Descr, type_num: c_int) -> PyArray_VectorUnaryFunc];
+    impl_api![67; PyArray_FromDims(nd: c_int, d: *mut c_int, type_: c_int) -> *mut PyObject];
+    impl_api![68; PyArray_FromDimsAndDataAndDescr(nd: c_int, d: *mut c_int, descr: *mut PyArray_Descr, data: *mut c_char) -> *mut PyObject];
+    impl_api![69; PyArray_FromAny(op: *mut PyObject, newtype: *mut PyArray_Descr, min_depth: c_int, max_depth: c_int, flags: c_int, context: *mut PyObject) -> *mut PyObject];
+    impl_api![70; PyArray_EnsureArray(op: *mut PyObject) -> *mut PyObject];
+    impl_api![71; PyArray_EnsureAnyArray(op: *mut PyObject) -> *mut PyObject];
+    impl_api![72; PyArray_FromFile(fp: *mut FILE, dtype: *mut PyArray_Descr, num: npy_intp, sep: *mut c_char) -> *mut PyObject];
+    impl_api![73; PyArray_FromString(data: *mut c_char, slen: npy_intp, dtype: *mut PyArray_Descr, num: npy_intp, sep: *mut c_char) -> *mut PyObject];
+    impl_api![74; PyArray_FromBuffer(buf: *mut PyObject, type_: *mut PyArray_Descr, count: npy_intp, offset: npy_intp) -> *mut PyObject];
+    impl_api![75; PyArray_FromIter(obj: *mut PyObject, dtype: *mut PyArray_Descr, count: npy_intp) -> *mut PyObject];
+    impl_api![76; PyArray_Return(mp: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![77; PyArray_GetField(self_: *mut PyArrayObject, typed: *mut PyArray_Descr, offset: c_int) -> *mut PyObject];
+    impl_api![78; PyArray_SetField(self_: *mut PyArrayObject, dtype: *mut PyArray_Descr, offset: c_int, val: *mut PyObject) -> c_int];
+    impl_api![79; PyArray_Byteswap(self_: *mut PyArrayObject, inplace: npy_bool) -> *mut PyObject];
+    impl_api![80; PyArray_Resize(self_: *mut PyArrayObject, newshape: *mut PyArray_Dims, refcheck: c_int, order: NPY_ORDER) -> *mut PyObject];
+    impl_api![81; PyArray_MoveInto(dst: *mut PyArrayObject, src: *mut PyArrayObject) -> c_int];
+    impl_api![82; PyArray_CopyInto(dst: *mut PyArrayObject, src: *mut PyArrayObject) -> c_int];
+    impl_api![83; PyArray_CopyAnyInto(dst: *mut PyArrayObject, src: *mut PyArrayObject) -> c_int];
+    impl_api![84; PyArray_CopyObject(dest: *mut PyArrayObject, src_object: *mut PyObject) -> c_int];
+    impl_api![85; PyArray_NewCopy(obj: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
+    impl_api![86; PyArray_ToList(self_: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![87; PyArray_ToString(self_: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
+    impl_api![88; PyArray_ToFile(self_: *mut PyArrayObject, fp: *mut FILE, sep: *mut c_char, format: *mut c_char) -> c_int];
+    impl_api![89; PyArray_Dump(self_: *mut PyObject, file: *mut PyObject, protocol: c_int) -> c_int];
+    impl_api![90; PyArray_Dumps(self_: *mut PyObject, protocol: c_int) -> *mut PyObject];
+    impl_api![91; PyArray_ValidType(type_: c_int) -> c_int];
+    impl_api![92; PyArray_UpdateFlags(ret: *mut PyArrayObject, flagmask: c_int)];
+    impl_api![93; PyArray_New(subtype: *mut PyTypeObject, nd: c_int, dims: *mut npy_intp, type_num: c_int, strides: *mut npy_intp, data: *mut c_void, itemsize: c_int, flags: c_int, obj: *mut PyObject) -> *mut PyObject];
+    impl_api![94; PyArray_NewFromDescr(subtype: *mut PyTypeObject, descr: *mut PyArray_Descr, nd: c_int, dims: *mut npy_intp, strides: *mut npy_intp, data: *mut c_void, flags: c_int, obj: *mut PyObject) -> *mut PyObject];
+    impl_api![95; PyArray_DescrNew(base: *mut PyArray_Descr) -> *mut PyArray_Descr];
+    impl_api![96; PyArray_DescrNewFromType(type_num: c_int) -> *mut PyArray_Descr];
+    impl_api![97; PyArray_GetPriority(obj: *mut PyObject, default_: f64) -> f64];
+    impl_api![98; PyArray_IterNew(obj: *mut PyObject) -> *mut PyObject];
+    // impl_api![99; PyArray_MultiIterNew(n: c_int, ...) -> *mut PyObject];
+    impl_api![100; PyArray_PyIntAsInt(o: *mut PyObject) -> c_int];
+    impl_api![101; PyArray_PyIntAsIntp(o: *mut PyObject) -> npy_intp];
+    impl_api![102; PyArray_Broadcast(mit: *mut PyArrayMultiIterObject) -> c_int];
+    impl_api![103; PyArray_FillObjectArray(arr: *mut PyArrayObject, obj: *mut PyObject)];
+    impl_api![104; PyArray_FillWithScalar(arr: *mut PyArrayObject, obj: *mut PyObject) -> c_int];
+    impl_api![105; PyArray_CheckStrides(elsize: c_int, nd: c_int, numbytes: npy_intp, offset: npy_intp, dims: *mut npy_intp, newstrides: *mut npy_intp) -> npy_bool];
+    impl_api![106; PyArray_DescrNewByteorder(self_: *mut PyArray_Descr, newendian: c_char) -> *mut PyArray_Descr];
+    impl_api![107; PyArray_IterAllButAxis(obj: *mut PyObject, inaxis: *mut c_int) -> *mut PyObject];
+    impl_api![108; PyArray_CheckFromAny(op: *mut PyObject, descr: *mut PyArray_Descr, min_depth: c_int, max_depth: c_int, requires: c_int, context: *mut PyObject) -> *mut PyObject];
+    impl_api![109; PyArray_FromArray(arr: *mut PyArrayObject, newtype: *mut PyArray_Descr, flags: c_int) -> *mut PyObject];
+    impl_api![110; PyArray_FromInterface(origin: *mut PyObject) -> *mut PyObject];
+    impl_api![111; PyArray_FromStructInterface(input: *mut PyObject) -> *mut PyObject];
+    impl_api![112; PyArray_FromArrayAttr(op: *mut PyObject, typecode: *mut PyArray_Descr, context: *mut PyObject) -> *mut PyObject];
+    impl_api![113; PyArray_ScalarKind(typenum: c_int, arr: *mut *mut PyArrayObject) -> NPY_SCALARKIND];
+    impl_api![114; PyArray_CanCoerceScalar(thistype: c_int, neededtype: c_int, scalar: NPY_SCALARKIND) -> c_int];
+    impl_api![115; PyArray_NewFlagsObject(obj: *mut PyObject) -> *mut PyObject];
+    impl_api![116; PyArray_CanCastScalar(from: *mut PyTypeObject, to: *mut PyTypeObject) -> npy_bool];
+    impl_api![117; PyArray_CompareUCS4(s1: *mut npy_ucs4, s2: *mut npy_ucs4, len: usize) -> c_int];
+    impl_api![118; PyArray_RemoveSmallest(multi: *mut PyArrayMultiIterObject) -> c_int];
+    impl_api![119; PyArray_ElementStrides(obj: *mut PyObject) -> c_int];
+    impl_api![120; PyArray_Item_INCREF(data: *mut c_char, descr: *mut PyArray_Descr)];
+    impl_api![121; PyArray_Item_XDECREF(data: *mut c_char, descr: *mut PyArray_Descr)];
+    impl_api![122; PyArray_FieldNames(fields: *mut PyObject) -> *mut PyObject];
+    impl_api![123; PyArray_Transpose(ap: *mut PyArrayObject, permute: *mut PyArray_Dims) -> *mut PyObject];
+    impl_api![124; PyArray_TakeFrom(self0: *mut PyArrayObject, indices0: *mut PyObject, axis: c_int, out: *mut PyArrayObject, clipmode: NPY_CLIPMODE) -> *mut PyObject];
+    impl_api![125; PyArray_PutTo(self_: *mut PyArrayObject, values0: *mut PyObject, indices0: *mut PyObject, clipmode: NPY_CLIPMODE) -> *mut PyObject];
+    impl_api![126; PyArray_PutMask(self_: *mut PyArrayObject, values0: *mut PyObject, mask0: *mut PyObject) -> *mut PyObject];
+    impl_api![127; PyArray_Repeat(aop: *mut PyArrayObject, op: *mut PyObject, axis: c_int) -> *mut PyObject];
+    impl_api![128; PyArray_Choose(ip: *mut PyArrayObject, op: *mut PyObject, out: *mut PyArrayObject, clipmode: NPY_CLIPMODE) -> *mut PyObject];
+    impl_api![129; PyArray_Sort(op: *mut PyArrayObject, axis: c_int, which: NPY_SORTKIND) -> c_int];
+    impl_api![130; PyArray_ArgSort(op: *mut PyArrayObject, axis: c_int, which: NPY_SORTKIND) -> *mut PyObject];
+    impl_api![131; PyArray_SearchSorted(op1: *mut PyArrayObject, op2: *mut PyObject, side: NPY_SEARCHSIDE, perm: *mut PyObject) -> *mut PyObject];
+    impl_api![132; PyArray_ArgMax(op: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![133; PyArray_ArgMin(op: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![134; PyArray_Reshape(self_: *mut PyArrayObject, shape: *mut PyObject) -> *mut PyObject];
+    impl_api![135; PyArray_Newshape(self_: *mut PyArrayObject, newdims: *mut PyArray_Dims, order: NPY_ORDER) -> *mut PyObject];
+    impl_api![136; PyArray_Squeeze(self_: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![137; PyArray_View(self_: *mut PyArrayObject, type_: *mut PyArray_Descr, pytype: *mut PyTypeObject) -> *mut PyObject];
+    impl_api![138; PyArray_SwapAxes(ap: *mut PyArrayObject, a1: c_int, a2: c_int) -> *mut PyObject];
+    impl_api![139; PyArray_Max(ap: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![140; PyArray_Min(ap: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![141; PyArray_Ptp(ap: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![142; PyArray_Mean(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![143; PyArray_Trace(self_: *mut PyArrayObject, offset: c_int, axis1: c_int, axis2: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![144; PyArray_Diagonal(self_: *mut PyArrayObject, offset: c_int, axis1: c_int, axis2: c_int) -> *mut PyObject];
+    impl_api![145; PyArray_Clip(self_: *mut PyArrayObject, min: *mut PyObject, max: *mut PyObject, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![146; PyArray_Conjugate(self_: *mut PyArrayObject, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![147; PyArray_Nonzero(self_: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![148; PyArray_Std(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject, variance: c_int) -> *mut PyObject];
+    impl_api![149; PyArray_Sum(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![150; PyArray_CumSum(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![151; PyArray_Prod(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![152; PyArray_CumProd(self_: *mut PyArrayObject, axis: c_int, rtype: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![153; PyArray_All(self_: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![154; PyArray_Any(self_: *mut PyArrayObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![155; PyArray_Compress(self_: *mut PyArrayObject, condition: *mut PyObject, axis: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![156; PyArray_Flatten(a: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
+    impl_api![157; PyArray_Ravel(arr: *mut PyArrayObject, order: NPY_ORDER) -> *mut PyObject];
+    impl_api![158; PyArray_MultiplyList(l1: *mut npy_intp, n: c_int) -> npy_intp];
+    impl_api![159; PyArray_MultiplyIntList(l1: *mut c_int, n: c_int) -> c_int];
+    impl_api![160; PyArray_GetPtr(obj: *mut PyArrayObject, ind: *mut npy_intp) -> *mut c_void];
+    impl_api![161; PyArray_CompareLists(l1: *mut npy_intp, l2: *mut npy_intp, n: c_int) -> c_int];
+    impl_api![162; PyArray_AsCArray(op: *mut *mut PyObject, ptr: *mut c_void, dims: *mut npy_intp, nd: c_int, typedescr: *mut PyArray_Descr) -> c_int];
+    impl_api![163; PyArray_As1D(op: *mut *mut PyObject, ptr: *mut *mut c_char, d1: *mut c_int, typecode: c_int) -> c_int];
+    impl_api![164; PyArray_As2D(op: *mut *mut PyObject, ptr: *mut *mut *mut c_char, d1: *mut c_int, d2: *mut c_int, typecode: c_int) -> c_int];
+    impl_api![165; PyArray_Free(op: *mut PyObject, ptr: *mut c_void) -> c_int];
+    impl_api![166; PyArray_Converter(object: *mut PyObject, address: *mut *mut PyObject) -> c_int];
+    impl_api![167; PyArray_IntpFromSequence(seq: *mut PyObject, vals: *mut npy_intp, maxvals: c_int) -> c_int];
+    impl_api![168; PyArray_Concatenate(op: *mut PyObject, axis: c_int) -> *mut PyObject];
+    impl_api![169; PyArray_InnerProduct(op1: *mut PyObject, op2: *mut PyObject) -> *mut PyObject];
+    impl_api![170; PyArray_MatrixProduct(op1: *mut PyObject, op2: *mut PyObject) -> *mut PyObject];
+    impl_api![171; PyArray_CopyAndTranspose(op: *mut PyObject) -> *mut PyObject];
+    impl_api![172; PyArray_Correlate(op1: *mut PyObject, op2: *mut PyObject, mode: c_int) -> *mut PyObject];
+    impl_api![173; PyArray_TypestrConvert(itemsize: c_int, gentype: c_int) -> c_int];
+    impl_api![174; PyArray_DescrConverter(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
+    impl_api![175; PyArray_DescrConverter2(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
+    impl_api![176; PyArray_IntpConverter(obj: *mut PyObject, seq: *mut PyArray_Dims) -> c_int];
+    impl_api![177; PyArray_BufferConverter(obj: *mut PyObject, buf: *mut PyArray_Chunk) -> c_int];
+    impl_api![178; PyArray_AxisConverter(obj: *mut PyObject, axis: *mut c_int) -> c_int];
+    impl_api![179; PyArray_BoolConverter(object: *mut PyObject, val: *mut npy_bool) -> c_int];
+    impl_api![180; PyArray_ByteorderConverter(obj: *mut PyObject, endian: *mut c_char) -> c_int];
+    impl_api![181; PyArray_OrderConverter(object: *mut PyObject, val: *mut NPY_ORDER) -> c_int];
+    impl_api![182; PyArray_EquivTypes(type1: *mut PyArray_Descr, type2: *mut PyArray_Descr) -> c_uchar];
+    impl_api![183; PyArray_Zeros(nd: c_int, dims: *mut npy_intp, type_: *mut PyArray_Descr, is_f_order: c_int) -> *mut PyObject];
+    impl_api![184; PyArray_Empty(nd: c_int, dims: *mut npy_intp, type_: *mut PyArray_Descr, is_f_order: c_int) -> *mut PyObject];
+    impl_api![185; PyArray_Where(condition: *mut PyObject, x: *mut PyObject, y: *mut PyObject) -> *mut PyObject];
+    impl_api![186; PyArray_Arange(start: f64, stop: f64, step: f64, type_num: c_int) -> *mut PyObject];
+    impl_api![187; PyArray_ArangeObj(start: *mut PyObject, stop: *mut PyObject, step: *mut PyObject, dtype: *mut PyArray_Descr) -> *mut PyObject];
+    impl_api![188; PyArray_SortkindConverter(obj: *mut PyObject, sortkind: *mut NPY_SORTKIND) -> c_int];
+    impl_api![189; PyArray_LexSort(sort_keys: *mut PyObject, axis: c_int) -> *mut PyObject];
+    impl_api![190; PyArray_Round(a: *mut PyArrayObject, decimals: c_int, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![191; PyArray_EquivTypenums(typenum1: c_int, typenum2: c_int) -> c_uchar];
+    impl_api![192; PyArray_RegisterDataType(descr: *mut PyArray_Descr) -> c_int];
+    impl_api![193; PyArray_RegisterCastFunc(descr: *mut PyArray_Descr, totype: c_int, castfunc: PyArray_VectorUnaryFunc) -> c_int];
+    impl_api![194; PyArray_RegisterCanCast(descr: *mut PyArray_Descr, totype: c_int, scalar: NPY_SCALARKIND) -> c_int];
+    impl_api![195; PyArray_InitArrFuncs(f: *mut PyArray_ArrFuncs)];
+    impl_api![196; PyArray_IntTupleFromIntp(len: c_int, vals: *mut npy_intp) -> *mut PyObject];
+    impl_api![197; PyArray_TypeNumFromName(str: *mut c_char) -> c_int];
+    impl_api![198; PyArray_ClipmodeConverter(object: *mut PyObject, val: *mut NPY_CLIPMODE) -> c_int];
+    impl_api![199; PyArray_OutputConverter(object: *mut PyObject, address: *mut *mut PyArrayObject) -> c_int];
+    impl_api![200; PyArray_BroadcastToShape(obj: *mut PyObject, dims: *mut npy_intp, nd: c_int) -> *mut PyObject];
+    impl_api![201; _PyArray_SigintHandler(signum: c_int)];
+    impl_api![202; _PyArray_GetSigintBuf() -> *mut c_void];
+    impl_api![203; PyArray_DescrAlignConverter(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
+    impl_api![204; PyArray_DescrAlignConverter2(obj: *mut PyObject, at: *mut *mut PyArray_Descr) -> c_int];
+    impl_api![205; PyArray_SearchsideConverter(obj: *mut PyObject, addr: *mut c_void) -> c_int];
+    impl_api![206; PyArray_CheckAxis(arr: *mut PyArrayObject, axis: *mut c_int, flags: c_int) -> *mut PyObject];
+    impl_api![207; PyArray_OverflowMultiplyList(l1: *mut npy_intp, n: c_int) -> npy_intp];
+    impl_api![208; PyArray_CompareString(s1: *mut c_char, s2: *mut c_char, len: usize) -> c_int];
+    // impl_api![209; PyArray_MultiIterFromObjects(mps: *mut *mut PyObject, n: c_int, nadd: c_int, ...) -> *mut PyObject];
+    impl_api![210; PyArray_GetEndianness() -> c_int];
+    impl_api![211; PyArray_GetNDArrayCFeatureVersion() -> c_uint];
+    impl_api![212; PyArray_Correlate2(op1: *mut PyObject, op2: *mut PyObject, mode: c_int) -> *mut PyObject];
+    impl_api![213; PyArray_NeighborhoodIterNew(x: *mut PyArrayIterObject, bounds: *mut npy_intp, mode: c_int, fill: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![219; PyArray_SetDatetimeParseFunction(op: *mut PyObject)];
+    impl_api![220; PyArray_DatetimeToDatetimeStruct(val: npy_datetime, fr: NPY_DATETIMEUNIT, result: *mut npy_datetimestruct)];
+    impl_api![221; PyArray_TimedeltaToTimedeltaStruct(val: npy_timedelta, fr: NPY_DATETIMEUNIT, result: *mut npy_timedeltastruct)];
+    impl_api![222; PyArray_DatetimeStructToDatetime(fr: NPY_DATETIMEUNIT, d: *mut npy_datetimestruct) -> npy_datetime];
+    impl_api![223; PyArray_TimedeltaStructToTimedelta(fr: NPY_DATETIMEUNIT, d: *mut npy_timedeltastruct) -> npy_datetime];
+    impl_api![224; NpyIter_New(op: *mut PyArrayObject, flags: npy_uint32, order: NPY_ORDER, casting: NPY_CASTING, dtype: *mut PyArray_Descr) -> *mut NpyIter];
+    impl_api![225; NpyIter_MultiNew(nop: c_int, op_in: *mut *mut PyArrayObject, flags: npy_uint32, order: NPY_ORDER, casting: NPY_CASTING, op_flags: *mut npy_uint32, op_request_dtypes: *mut *mut PyArray_Descr) -> *mut NpyIter];
+    impl_api![226; NpyIter_AdvancedNew(nop: c_int, op_in: *mut *mut PyArrayObject, flags: npy_uint32, order: NPY_ORDER, casting: NPY_CASTING, op_flags: *mut npy_uint32, op_request_dtypes: *mut *mut PyArray_Descr, oa_ndim: c_int, op_axes: *mut *mut c_int, itershape: *mut npy_intp, buffersize: npy_intp) -> *mut NpyIter];
+    impl_api![227; NpyIter_Copy(iter: *mut NpyIter) -> *mut NpyIter];
+    impl_api![228; NpyIter_Deallocate(iter: *mut NpyIter) -> c_int];
+    impl_api![229; NpyIter_HasDelayedBufAlloc(iter: *mut NpyIter) -> npy_bool];
+    impl_api![230; NpyIter_HasExternalLoop(iter: *mut NpyIter) -> npy_bool];
+    impl_api![231; NpyIter_EnableExternalLoop(iter: *mut NpyIter) -> c_int];
+    impl_api![232; NpyIter_GetInnerStrideArray(iter: *mut NpyIter) -> *mut npy_intp];
+    impl_api![233; NpyIter_GetInnerLoopSizePtr(iter: *mut NpyIter) -> *mut npy_intp];
+    impl_api![234; NpyIter_Reset(iter: *mut NpyIter, errmsg: *mut *mut c_char) -> c_int];
+    impl_api![235; NpyIter_ResetBasePointers(iter: *mut NpyIter, baseptrs: *mut *mut c_char, errmsg: *mut *mut c_char) -> c_int];
+    impl_api![236; NpyIter_ResetToIterIndexRange(iter: *mut NpyIter, istart: npy_intp, iend: npy_intp, errmsg: *mut *mut c_char) -> c_int];
+    impl_api![237; NpyIter_GetNDim(iter: *mut NpyIter) -> c_int];
+    impl_api![238; NpyIter_GetNOp(iter: *mut NpyIter) -> c_int];
+    impl_api![239; NpyIter_GetIterNext(iter: *mut NpyIter, errmsg: *mut *mut c_char) -> NpyIter_IterNextFunc];
+    impl_api![240; NpyIter_GetIterSize(iter: *mut NpyIter) -> npy_intp];
+    impl_api![241; NpyIter_GetIterIndexRange(iter: *mut NpyIter, istart: *mut npy_intp, iend: *mut npy_intp)];
+    impl_api![242; NpyIter_GetIterIndex(iter: *mut NpyIter) -> npy_intp];
+    impl_api![243; NpyIter_GotoIterIndex(iter: *mut NpyIter, iterindex: npy_intp) -> c_int];
+    impl_api![244; NpyIter_HasMultiIndex(iter: *mut NpyIter) -> npy_bool];
+    impl_api![245; NpyIter_GetShape(iter: *mut NpyIter, outshape: *mut npy_intp) -> c_int];
+    impl_api![246; NpyIter_GetGetMultiIndex(iter: *mut NpyIter, errmsg: *mut *mut c_char) -> NpyIter_GetMultiIndexFunc];
+    impl_api![247; NpyIter_GotoMultiIndex(iter: *mut NpyIter, multi_index: *mut npy_intp) -> c_int];
+    impl_api![248; NpyIter_RemoveMultiIndex(iter: *mut NpyIter) -> c_int];
+    impl_api![249; NpyIter_HasIndex(iter: *mut NpyIter) -> npy_bool];
+    impl_api![250; NpyIter_IsBuffered(iter: *mut NpyIter) -> npy_bool];
+    impl_api![251; NpyIter_IsGrowInner(iter: *mut NpyIter) -> npy_bool];
+    impl_api![252; NpyIter_GetBufferSize(iter: *mut NpyIter) -> npy_intp];
+    impl_api![253; NpyIter_GetIndexPtr(iter: *mut NpyIter) -> *mut npy_intp];
+    impl_api![254; NpyIter_GotoIndex(iter: *mut NpyIter, flat_index: npy_intp) -> c_int];
+    impl_api![255; NpyIter_GetDataPtrArray(iter: *mut NpyIter) -> *mut *mut c_char];
+    impl_api![256; NpyIter_GetDescrArray(iter: *mut NpyIter) -> *mut *mut PyArray_Descr];
+    impl_api![257; NpyIter_GetOperandArray(iter: *mut NpyIter) -> *mut *mut PyArrayObject];
+    impl_api![258; NpyIter_GetIterView(iter: *mut NpyIter, i: npy_intp) -> *mut PyArrayObject];
+    impl_api![259; NpyIter_GetReadFlags(iter: *mut NpyIter, outreadflags: *mut c_char)];
+    impl_api![260; NpyIter_GetWriteFlags(iter: *mut NpyIter, outwriteflags: *mut c_char)];
+    impl_api![261; NpyIter_DebugPrint(iter: *mut NpyIter)];
+    impl_api![262; NpyIter_IterationNeedsAPI(iter: *mut NpyIter) -> npy_bool];
+    impl_api![263; NpyIter_GetInnerFixedStrideArray(iter: *mut NpyIter, out_strides: *mut npy_intp)];
+    impl_api![264; NpyIter_RemoveAxis(iter: *mut NpyIter, axis: c_int) -> c_int];
+    impl_api![265; NpyIter_GetAxisStrideArray(iter: *mut NpyIter, axis: c_int) -> *mut npy_intp];
+    impl_api![266; NpyIter_RequiresBuffering(iter: *mut NpyIter) -> npy_bool];
+    impl_api![267; NpyIter_GetInitialDataPtrArray(iter: *mut NpyIter) -> *mut *mut c_char];
+    impl_api![268; NpyIter_CreateCompatibleStrides(iter: *mut NpyIter, itemsize: npy_intp, outstrides: *mut npy_intp) -> c_int];
+    impl_api![269; PyArray_CastingConverter(obj: *mut PyObject, casting: *mut NPY_CASTING) -> c_int];
+    impl_api![270; PyArray_CountNonzero(self_: *mut PyArrayObject) -> npy_intp];
+    impl_api![271; PyArray_PromoteTypes(type1: *mut PyArray_Descr, type2: *mut PyArray_Descr) -> *mut PyArray_Descr];
+    impl_api![272; PyArray_MinScalarType(arr: *mut PyArrayObject) -> *mut PyArray_Descr];
+    impl_api![273; PyArray_ResultType(narrs: npy_intp, arr: *mut *mut PyArrayObject, ndtypes: npy_intp, dtypes: *mut *mut PyArray_Descr) -> *mut PyArray_Descr];
+    impl_api![274; PyArray_CanCastArrayTo(arr: *mut PyArrayObject, to: *mut PyArray_Descr, casting: NPY_CASTING) -> npy_bool];
+    impl_api![275; PyArray_CanCastTypeTo(from: *mut PyArray_Descr, to: *mut PyArray_Descr, casting: NPY_CASTING) -> npy_bool];
+    impl_api![276; PyArray_EinsteinSum(subscripts: *mut c_char, nop: npy_intp, op_in: *mut *mut PyArrayObject, dtype: *mut PyArray_Descr, order: NPY_ORDER, casting: NPY_CASTING, out: *mut PyArrayObject) -> *mut PyArrayObject];
+    impl_api![277; PyArray_NewLikeArray(prototype: *mut PyArrayObject, order: NPY_ORDER, dtype: *mut PyArray_Descr, subok: c_int) -> *mut PyObject];
+    impl_api![278; PyArray_GetArrayParamsFromObject(op: *mut PyObject, requested_dtype: *mut PyArray_Descr, writeable: npy_bool, out_dtype: *mut *mut PyArray_Descr, out_ndim: *mut c_int, out_dims: *mut npy_intp, out_arr: *mut *mut PyArrayObject, context: *mut PyObject) -> c_int];
+    impl_api![279; PyArray_ConvertClipmodeSequence(object: *mut PyObject, modes: *mut NPY_CLIPMODE, n: c_int) -> c_int];
+    impl_api![280; PyArray_MatrixProduct2(op1: *mut PyObject, op2: *mut PyObject, out: *mut PyArrayObject) -> *mut PyObject];
+    impl_api![281; NpyIter_IsFirstVisit(iter: *mut NpyIter, iop: c_int) -> npy_bool];
+    impl_api![282; PyArray_SetBaseObject(arr: *mut PyArrayObject, obj: *mut PyObject) -> c_int];
+    impl_api![283; PyArray_CreateSortedStridePerm(ndim: c_int, strides: *mut npy_intp, out_strideperm: *mut npy_stride_sort_item)];
+    impl_api![284; PyArray_RemoveAxesInPlace(arr: *mut PyArrayObject, flags: *mut npy_bool)];
+    impl_api![285; PyArray_DebugPrint(obj: *mut PyArrayObject)];
+    impl_api![286; PyArray_FailUnlessWriteable(obj: *mut PyArrayObject, name: *const c_char) -> c_int];
+    impl_api![287; PyArray_SetUpdateIfCopyBase(arr: *mut PyArrayObject, base: *mut PyArrayObject) -> c_int];
+    impl_api![288; PyDataMem_NEW(size: usize) -> *mut c_void];
+    impl_api![289; PyDataMem_FREE(ptr: *mut c_void)];
+    impl_api![290; PyDataMem_RENEW(ptr: *mut c_void, size: usize) -> *mut c_void];
+    impl_api![291; PyDataMem_SetEventHook(newhook: PyDataMem_EventHookFunc, user_data: *mut c_void, old_data: *mut *mut c_void) -> PyDataMem_EventHookFunc];
+    impl_api![293; PyArray_MapIterSwapAxes(mit: *mut PyArrayMapIterObject, ret: *mut *mut PyArrayObject, getmap: c_int)];
+    impl_api![294; PyArray_MapIterArray(a: *mut PyArrayObject, index: *mut PyObject) -> *mut PyObject];
+    impl_api![295; PyArray_MapIterNext(mit: *mut PyArrayMapIterObject)];
+    impl_api![296; PyArray_Partition(op: *mut PyArrayObject, ktharray: *mut PyArrayObject, axis: c_int, which: NPY_SELECTKIND) -> c_int];
+    impl_api![297; PyArray_ArgPartition(op: *mut PyArrayObject, ktharray: *mut PyArrayObject, axis: c_int, which: NPY_SELECTKIND) -> *mut PyObject];
+    impl_api![298; PyArray_SelectkindConverter(obj: *mut PyObject, selectkind: *mut NPY_SELECTKIND) -> c_int];
+    impl_api![299; PyDataMem_NEW_ZEROED(size: usize, elsize: usize) -> *mut c_void];
+    impl_api![300; PyArray_CheckAnyScalarExact(obj: *mut PyObject) -> c_int];
+    impl_api![301; PyArray_MapIterArrayCopyIfOverlap(a: *mut PyArrayObject, index: *mut PyObject, copy_if_overlap: c_int, extra_op: *mut PyArrayObject) -> *mut PyObject];
 }
 
 /// Define PyTypeObject related to Array API
@@ -377,10 +357,20 @@ impl_array_type!(
 
 #[allow(non_snake_case)]
 pub unsafe fn PyArray_Check(op: *mut PyObject) -> c_int {
-    ffi::PyObject_TypeCheck(op, PyArrayAPI.get_type_object(ArrayType::PyArray_Type))
+    ffi::PyObject_TypeCheck(op, PY_ARRAY_API.get_type_object(ArrayType::PyArray_Type))
 }
 
 #[allow(non_snake_case)]
 pub unsafe fn PyArray_CheckExact(op: *mut PyObject) -> c_int {
-    (ffi::Py_TYPE(op) == PyArrayAPI.get_type_object(ArrayType::PyArray_Type)) as c_int
+    (ffi::Py_TYPE(op) == PY_ARRAY_API.get_type_object(ArrayType::PyArray_Type)) as c_int
+}
+
+#[test]
+fn call_api() {
+    unsafe {
+        assert_eq!(
+            PY_ARRAY_API.PyArray_MultiplyIntList([1, 2, 3].as_mut_ptr(), 3),
+            6
+        );
+    }
 }

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -10,10 +10,33 @@ use npyffi::*;
 pub(crate) const MOD_NAME: &str = "numpy.core.multiarray";
 const CAPSULE_NAME: &str = "_ARRAY_API";
 
+/// A global variable which stores a ['capsule'](https://docs.python.org/3/c-api/capsule.html)
+/// pointer to [Numpy Array API](https://docs.scipy.org/doc/numpy/reference/c-api.array.html).
+///
+/// You can acceess raw c APIs via this variable and its Deref implementation.
+///
+/// See [PyArrayAPI](struct.PyArrayAPI.html) for what methods you can use via this variable.
+///
+/// # Example
+/// ```
+/// # extern crate pyo3; extern crate numpy; fn main() {
+/// use numpy::{PyArray, npyffi::types::NPY_SORTKIND, PY_ARRAY_API};
+/// use pyo3::Python;
+/// let gil = Python::acquire_gil();
+/// let array: &PyArray<i32> = PyArray::arange(gil.python(), 2.0, 5.0, 1.0);
+/// array.as_slice_mut().unwrap().swap(0, 1);
+/// assert_eq!(array.as_slice().unwrap(), &[3, 2, 4]);
+/// unsafe {
+///     PY_ARRAY_API.PyArray_Sort(array.as_array_ptr(), 0, NPY_SORTKIND::NPY_QUICKSORT);
+/// }
+/// assert_eq!(array.as_slice().unwrap(), &[2, 3, 4])
+/// # }
+/// ```
 pub static PY_ARRAY_API: PyArrayAPI = PyArrayAPI {
     __private_field: (),
 };
 
+///
 pub struct PyArrayAPI {
     __private_field: (),
 }
@@ -33,7 +56,6 @@ impl Deref for PyArrayAPI {
 }
 
 #[allow(non_camel_case_types)]
-#[doc(hidden)]
 pub struct PyArrayAPI_Inner(*const *const c_void);
 
 impl PyArrayAPI_Inner {

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -9,6 +9,34 @@
 //! - http://docs.python.jp/3/c-api/
 //! - http://dgrunwald.github.io/rust-pyo3/doc/pyo3/
 
+use pyo3::{ffi, ObjectProtocol, Python, ToPyPointer};
+use std::os::raw::c_void;
+use std::ptr::null_mut;
+
+fn get_numpy_api(module: &str, capsule: &str) -> *const *const c_void {
+    let gil = Python::acquire_gil();
+    let numpy = gil
+        .python()
+        .import("numpy.core.multiarray")
+        .expect("Failed to import numpy.core.multiarray");
+    let capsule = numpy
+        .getattr("_ARRAY_API")
+        .expect("Failed to import numpy.core.multiarray._ARRAY_API");
+    unsafe { ffi::PyCapsule_GetPointer(capsule.as_ptr(), null_mut()) as *const *const c_void }
+}
+
+// Define Array&UFunc APIs
+macro_rules! impl_api {
+    [ $offset:expr; $fname:ident ( $($arg:ident : $t:ty),* ) $( -> $ret:ty )* ] => {
+        #[allow(non_snake_case)]
+        pub unsafe fn $fname(&self, $($arg : $t), *) $( -> $ret )* {
+            let fptr = self.0.offset($offset)
+                               as (*const extern fn ($($arg : $t), *) $( -> $ret )* );
+            (*fptr)($($arg), *)
+        }
+    }
+}
+
 pub mod array;
 pub mod objects;
 pub mod types;

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -36,7 +36,6 @@ impl Deref for PyUFuncAPI {
 }
 
 #[allow(non_camel_case_types)]
-#[doc(hidden)]
 pub struct PyUFuncAPI_Inner(*const *const c_void);
 
 impl PyUFuncAPI_Inner {

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -1,104 +1,85 @@
-//! Low-Level binding for UFunc API
-//!
-//! https://docs.scipy.org/doc/numpy/reference/c-api.ufunc.html
+//! Low-Level binding for [UFunc API](https://docs.scipy.org/doc/numpy/reference/c-api.ufunc.html)
 
 use std::ops::Deref;
 use std::os::raw::*;
-use std::ptr::null_mut;
+use std::ptr;
+use std::sync::{Once, ONCE_INIT};
 
-use pyo3::ffi;
-use pyo3::ffi::{PyObject, PyTypeObject};
-use pyo3::{ObjectProtocol, PyModule, PyResult, Python, ToPyPointer};
+use pyo3::ffi::PyObject;
 
+use super::get_numpy_api;
 use super::objects::*;
 use super::types::*;
 
-/// Low-Level binding for [UFunc API](https://docs.scipy.org/doc/numpy/reference/c-api.ufunc.html)
-///
-/// Most of UFunc API is exposed as the related function of this module object.
-pub struct PyUFuncModule<'py> {
-    numpy: &'py PyModule,
-    api: *const *const c_void,
+const MOD_NAME: &str = "numpy.core.umath";
+const CAPSULE_NAME: &str = "_UFUNC_API";
+
+pub static PY_UFUNC_API: PyUFuncAPI = PyUFuncAPI {
+    __private_field: (),
+};
+
+pub struct PyUFuncAPI {
+    __private_field: (),
 }
 
-impl<'py> Deref for PyUFuncModule<'py> {
-    type Target = PyModule;
+impl Deref for PyUFuncAPI {
+    type Target = PyUFuncAPI_Inner;
     fn deref(&self) -> &Self::Target {
-        self.numpy
+        static INIT_API: Once = ONCE_INIT;
+        static mut UFUNC_API_CACHE: PyUFuncAPI_Inner = PyUFuncAPI_Inner(ptr::null());
+        INIT_API.call_once(|| {
+            unsafe {
+                UFUNC_API_CACHE = PyUFuncAPI_Inner(get_numpy_api(MOD_NAME, CAPSULE_NAME));
+            };
+        });
+        unsafe { &UFUNC_API_CACHE }
     }
 }
 
-/// Define UFunc API in PyUFuncModule
-macro_rules! pyufunc_api {
-    [ $offset:expr; $fname:ident ( $($arg:ident : $t:ty),* ) $( -> $ret:ty )* ] => {
-#[allow(non_snake_case)]
-pub unsafe fn $fname(&self, $($arg : $t), *) $( -> $ret )* {
-    let fptr = self.api.offset($offset) as (*const extern fn ($($arg : $t), *) $( -> $ret )* );
-    (*fptr)($($arg), *)
-}
-}} // pyufunc_api!
+#[allow(non_camel_case_types)]
+#[doc(hidden)]
+pub struct PyUFuncAPI_Inner(*const *const c_void);
 
-impl<'py> PyUFuncModule<'py> {
-    /// Import `numpy.core.umath` to use UFunc API.
-    pub fn import(py: Python<'py>) -> PyResult<Self> {
-        let numpy = py.import("numpy.core.umath")?;
-        let c_api = numpy.getattr("_UFUNC_API")?;
-        let api = unsafe {
-            ffi::PyCapsule_GetPointer(c_api.as_ptr(), null_mut()) as *const *const c_void
-        };
-        Ok(Self {
-            numpy: numpy,
-            api: api,
-        })
-    }
-
-    pub unsafe fn get_pyufunc_type(&self) -> *mut PyTypeObject {
-        *self.api as *mut PyTypeObject
-    }
-
-    pub fn as_pymodule(&self) -> &'py PyModule {
-        self.numpy
-    }
-
-    pyufunc_api![1; PyUFunc_FromFuncAndData(func: *mut PyUFuncGenericFunction, data: *mut *mut c_void, types: *mut c_char, ntypes: c_int, nin: c_int, nout: c_int, identity: c_int, name: *const c_char, doc: *const c_char, unused: c_int) -> *mut PyObject];
-    pyufunc_api![2; PyUFunc_RegisterLoopForType(ufunc: *mut PyUFuncObject, usertype: c_int, function: PyUFuncGenericFunction, arg_types: *mut c_int, data: *mut c_void) -> c_int];
-    pyufunc_api![3; PyUFunc_GenericFunction(ufunc: *mut PyUFuncObject, args: *mut PyObject, kwds: *mut PyObject, op: *mut *mut PyArrayObject) -> c_int];
-    pyufunc_api![4; PyUFunc_f_f_As_d_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![5; PyUFunc_d_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![6; PyUFunc_f_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![7; PyUFunc_g_g(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![8; PyUFunc_F_F_As_D_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![9; PyUFunc_F_F(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![10; PyUFunc_D_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![11; PyUFunc_G_G(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![12; PyUFunc_O_O(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![13; PyUFunc_ff_f_As_dd_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![14; PyUFunc_ff_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![15; PyUFunc_dd_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![16; PyUFunc_gg_g(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![17; PyUFunc_FF_F_As_DD_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![18; PyUFunc_DD_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![19; PyUFunc_FF_F(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![20; PyUFunc_GG_G(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![21; PyUFunc_OO_O(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![22; PyUFunc_O_O_method(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![23; PyUFunc_OO_O_method(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![24; PyUFunc_On_Om(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![25; PyUFunc_GetPyValues(name: *mut c_char, bufsize: *mut c_int, errmask: *mut c_int, errobj: *mut *mut PyObject) -> c_int];
-    pyufunc_api![26; PyUFunc_checkfperr(errmask: c_int, errobj: *mut PyObject, first: *mut c_int) -> c_int];
-    pyufunc_api![27; PyUFunc_clearfperr()];
-    pyufunc_api![28; PyUFunc_getfperr() -> c_int];
-    pyufunc_api![29; PyUFunc_handlefperr(errmask: c_int, errobj: *mut PyObject, retstatus: c_int, first: *mut c_int) -> c_int];
-    pyufunc_api![30; PyUFunc_ReplaceLoopBySignature(func: *mut PyUFuncObject, newfunc: PyUFuncGenericFunction, signature: *mut c_int, oldfunc: *mut PyUFuncGenericFunction) -> c_int];
-    pyufunc_api![31; PyUFunc_FromFuncAndDataAndSignature(func: *mut PyUFuncGenericFunction, data: *mut *mut c_void, types: *mut c_char, ntypes: c_int, nin: c_int, nout: c_int, identity: c_int, name: *const c_char, doc: *const c_char, unused: c_int, signature: *const c_char) -> *mut PyObject];
-    pyufunc_api![32; PyUFunc_SetUsesArraysAsData(data: *mut *mut c_void, i: usize) -> c_int];
-    pyufunc_api![33; PyUFunc_e_e(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![34; PyUFunc_e_e_As_f_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![35; PyUFunc_e_e_As_d_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![36; PyUFunc_ee_e(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![37; PyUFunc_ee_e_As_ff_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![38; PyUFunc_ee_e_As_dd_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
-    pyufunc_api![39; PyUFunc_DefaultTypeResolver(ufunc: *mut PyUFuncObject, casting: NPY_CASTING, operands: *mut *mut PyArrayObject, type_tup: *mut PyObject, out_dtypes: *mut *mut PyArray_Descr) -> c_int];
-    pyufunc_api![40; PyUFunc_ValidateCasting(ufunc: *mut PyUFuncObject, casting: NPY_CASTING, operands: *mut *mut PyArrayObject, dtypes: *mut *mut PyArray_Descr) -> c_int];
-    pyufunc_api![41; PyUFunc_RegisterLoopForDescr(ufunc: *mut PyUFuncObject, user_dtype: *mut PyArray_Descr, function: PyUFuncGenericFunction, arg_dtypes: *mut *mut PyArray_Descr, data: *mut c_void) -> c_int];
+impl PyUFuncAPI_Inner {
+    impl_api![1; PyUFunc_FromFuncAndData(func: *mut PyUFuncGenericFunction, data: *mut *mut c_void, types: *mut c_char, ntypes: c_int, nin: c_int, nout: c_int, identity: c_int, name: *const c_char, doc: *const c_char, unused: c_int) -> *mut PyObject];
+    impl_api![2; PyUFunc_RegisterLoopForType(ufunc: *mut PyUFuncObject, usertype: c_int, function: PyUFuncGenericFunction, arg_types: *mut c_int, data: *mut c_void) -> c_int];
+    impl_api![3; PyUFunc_GenericFunction(ufunc: *mut PyUFuncObject, args: *mut PyObject, kwds: *mut PyObject, op: *mut *mut PyArrayObject) -> c_int];
+    impl_api![4; PyUFunc_f_f_As_d_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![5; PyUFunc_d_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![6; PyUFunc_f_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![7; PyUFunc_g_g(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![8; PyUFunc_F_F_As_D_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![9; PyUFunc_F_F(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![10; PyUFunc_D_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![11; PyUFunc_G_G(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![12; PyUFunc_O_O(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![13; PyUFunc_ff_f_As_dd_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![14; PyUFunc_ff_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![15; PyUFunc_dd_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![16; PyUFunc_gg_g(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![17; PyUFunc_FF_F_As_DD_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![18; PyUFunc_DD_D(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![19; PyUFunc_FF_F(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![20; PyUFunc_GG_G(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![21; PyUFunc_OO_O(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![22; PyUFunc_O_O_method(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![23; PyUFunc_OO_O_method(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![24; PyUFunc_On_Om(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![25; PyUFunc_GetPyValues(name: *mut c_char, bufsize: *mut c_int, errmask: *mut c_int, errobj: *mut *mut PyObject) -> c_int];
+    impl_api![26; PyUFunc_checkfperr(errmask: c_int, errobj: *mut PyObject, first: *mut c_int) -> c_int];
+    impl_api![27; PyUFunc_clearfperr()];
+    impl_api![28; PyUFunc_getfperr() -> c_int];
+    impl_api![29; PyUFunc_handlefperr(errmask: c_int, errobj: *mut PyObject, retstatus: c_int, first: *mut c_int) -> c_int];
+    impl_api![30; PyUFunc_ReplaceLoopBySignature(func: *mut PyUFuncObject, newfunc: PyUFuncGenericFunction, signature: *mut c_int, oldfunc: *mut PyUFuncGenericFunction) -> c_int];
+    impl_api![31; PyUFunc_FromFuncAndDataAndSignature(func: *mut PyUFuncGenericFunction, data: *mut *mut c_void, types: *mut c_char, ntypes: c_int, nin: c_int, nout: c_int, identity: c_int, name: *const c_char, doc: *const c_char, unused: c_int, signature: *const c_char) -> *mut PyObject];
+    impl_api![32; PyUFunc_SetUsesArraysAsData(data: *mut *mut c_void, i: usize) -> c_int];
+    impl_api![33; PyUFunc_e_e(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![34; PyUFunc_e_e_As_f_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![35; PyUFunc_e_e_As_d_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![36; PyUFunc_ee_e(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![37; PyUFunc_ee_e_As_ff_f(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![38; PyUFunc_ee_e_As_dd_d(args: *mut *mut c_char, dimensions: *mut npy_intp, steps: *mut npy_intp, func: *mut c_void)];
+    impl_api![39; PyUFunc_DefaultTypeResolver(ufunc: *mut PyUFuncObject, casting: NPY_CASTING, operands: *mut *mut PyArrayObject, type_tup: *mut PyObject, out_dtypes: *mut *mut PyArray_Descr) -> c_int];
+    impl_api![40; PyUFunc_ValidateCasting(ufunc: *mut PyUFuncObject, casting: NPY_CASTING, operands: *mut *mut PyArrayObject, dtypes: *mut *mut PyArray_Descr) -> c_int];
+    impl_api![41; PyUFunc_RegisterLoopForDescr(ufunc: *mut PyUFuncObject, user_dtype: *mut PyArray_Descr, function: PyUFuncGenericFunction, arg_dtypes: *mut *mut PyArray_Descr, data: *mut c_void) -> c_int];
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -9,10 +9,9 @@ use pyo3::prelude::*;
 #[test]
 fn new() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
     let n = 3;
     let m = 5;
-    let arr = PyArray::<f64>::new(gil.python(), &np, &[n, m]);
+    let arr = PyArray::<f64>::new(gil.python(), &[n, m]);
     assert!(arr.ndim() == 2);
     assert!(arr.dims() == [n, m]);
     assert!(arr.strides() == [m as isize * 8, 8]);
@@ -21,15 +20,14 @@ fn new() {
 #[test]
 fn zeros() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
     let n = 3;
     let m = 5;
-    let arr = PyArray::<f64>::zeros(gil.python(), &np, &[n, m], false);
+    let arr = PyArray::<f64>::zeros(gil.python(), &[n, m], false);
     assert!(arr.ndim() == 2);
     assert!(arr.dims() == [n, m]);
     assert!(arr.strides() == [m as isize * 8, 8]);
 
-    let arr = PyArray::<f64>::zeros(gil.python(), &np, &[n, m], true);
+    let arr = PyArray::<f64>::zeros(gil.python(), &[n, m], true);
     assert!(arr.ndim() == 2);
     assert!(arr.dims() == [n, m]);
     assert!(arr.strides() == [8, n as isize * 8]);
@@ -38,8 +36,7 @@ fn zeros() {
 #[test]
 fn arange() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
-    let arr = PyArray::<f64>::arange(gil.python(), &np, 0.0, 1.0, 0.1);
+    let arr = PyArray::<f64>::arange(gil.python(), 0.0, 1.0, 0.1);
     println!("ndim = {:?}", arr.ndim());
     println!("dims = {:?}", arr.dims());
     println!("array = {:?}", arr.as_slice().unwrap());
@@ -48,8 +45,7 @@ fn arange() {
 #[test]
 fn as_array() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
-    let arr = PyArray::<f64>::zeros(gil.python(), &np, &[3, 2, 4], false);
+    let arr = PyArray::<f64>::zeros(gil.python(), &[3, 2, 4], false);
     let a = arr.as_array().unwrap();
     assert_eq!(arr.shape(), a.shape());
     assert_eq!(
@@ -61,10 +57,9 @@ fn as_array() {
 #[test]
 fn into_pyarray_vec() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
 
     let a = vec![1, 2, 3];
-    let arr = a.into_pyarray(gil.python(), &np);
+    let arr = a.into_pyarray(gil.python());
     println!("arr.shape = {:?}", arr.shape());
     println!("arr = {:?}", arr.as_slice().unwrap());
     assert_eq!(arr.shape(), [3]);
@@ -73,14 +68,13 @@ fn into_pyarray_vec() {
 #[test]
 fn into_pyarray_array() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
 
     let a = Array3::<f64>::zeros((3, 4, 2));
     let shape = a.shape().iter().cloned().collect::<Vec<_>>();
     let strides = a.strides().iter().map(|d| d * 8).collect::<Vec<_>>();
     println!("a.shape   = {:?}", a.shape());
     println!("a.strides = {:?}", a.strides());
-    let pa = a.into_pyarray(gil.python(), &np);
+    let pa = a.into_pyarray(gil.python());
     println!("pa.shape   = {:?}", pa.shape());
     println!("pa.strides = {:?}", pa.strides());
     assert_eq!(pa.shape(), shape.as_slice());
@@ -90,8 +84,7 @@ fn into_pyarray_array() {
 #[test]
 fn iter_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
-    let arr = PyArray::from_iter(gil.python(), &np, (0..10).map(|x| x * x));
+    let arr = PyArray::from_iter(gil.python(), (0..10).map(|x| x * x));
     assert_eq!(
         arr.as_slice().unwrap(),
         &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
@@ -102,31 +95,28 @@ fn iter_to_pyarray() {
 fn is_instance() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();
-    let np = PyArrayModule::import(py).unwrap();
-    let arr = PyArray::<f64>::new(gil.python(), &np, &[3, 5]);
-    assert!(py.is_instance::<PyArray<f64>, _>(&arr).unwrap());
-    assert!(!py.is_instance::<pyo3::PyList, _>(&arr).unwrap());
+    let arr = PyArray::<f64>::new(gil.python(), &[3, 5]);
+    assert!(py.is_instance::<PyArray<f64>, _>(arr).unwrap());
+    assert!(!py.is_instance::<pyo3::PyList, _>(arr).unwrap());
 }
 
 #[test]
 fn from_vec2() {
     let vec2 = vec![vec![1, 2, 3]; 2];
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
-    let pyarray = PyArray::from_vec2(gil.python(), &np, &vec2).unwrap();
+    let pyarray = PyArray::from_vec2(gil.python(), &vec2).unwrap();
     assert_eq!(
         pyarray.as_array().unwrap(),
         array![[1, 2, 3], [1, 2, 3]].into_dyn()
     );
-    assert!(PyArray::from_vec2(gil.python(), &np, &vec![vec![1], vec![2, 3]]).is_err());
+    assert!(PyArray::from_vec2(gil.python(), &vec![vec![1], vec![2, 3]]).is_err());
 }
 
 #[test]
 fn from_vec3() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
     let vec3 = vec![vec![vec![1, 2]; 2]; 2];
-    let pyarray = PyArray::from_vec3(gil.python(), &np, &vec3).unwrap();
+    let pyarray = PyArray::from_vec3(gil.python(), &vec3).unwrap();
     assert_eq!(
         pyarray.as_array().unwrap(),
         array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]].into_dyn()
@@ -136,9 +126,9 @@ fn from_vec3() {
 #[test]
 fn from_eval() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
+    let np = get_array_module(gil.python()).unwrap();
     let dict = PyDict::new(gil.python());
-    dict.set_item("np", np.as_pymodule()).unwrap();
+    dict.set_item("np", np).unwrap();
     let pyarray: &PyArray<i32> = gil
         .python()
         .eval("np.array([1, 2, 3], dtype='int32')", Some(&dict), None)
@@ -151,9 +141,9 @@ fn from_eval() {
 #[test]
 fn from_eval_fail() {
     let gil = pyo3::Python::acquire_gil();
-    let np = PyArrayModule::import(gil.python()).unwrap();
+    let np = get_array_module(gil.python()).unwrap();
     let dict = PyDict::new(gil.python());
-    dict.set_item("np", np.as_pymodule()).unwrap();
+    dict.set_item("np", np).unwrap();
     let converted: Result<&PyArray<i32>, _> = gil
         .python()
         .eval("np.array([1, 2, 3], dtype='float64')", Some(&dict), None)
@@ -167,10 +157,9 @@ macro_rules! small_array_test {
         #[test]
         fn from_small_array() {
             let gil = pyo3::Python::acquire_gil();
-            let np = PyArrayModule::import(gil.python()).unwrap();
             $({
                 let array: [$t; 2] = [$t::min_value(), $t::max_value()];
-                let pyarray = array.into_pyarray(gil.python(), &np);
+                let pyarray = array.into_pyarray(gil.python());
                 assert_eq!(
                     pyarray.as_slice().unwrap(),
                     &[$t::min_value(), $t::max_value()]
@@ -186,10 +175,9 @@ small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64);
 fn array_cast() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();
-    let np = PyArrayModule::import(py).unwrap();
     let vec2 = vec![vec![1.0, 2.0, 3.0]; 2];
-    let arr_f64 = PyArray::from_vec2(gil.python(), &np, &vec2).unwrap();
-    let arr_i32: PyArray<i32> = arr_f64.cast(py, &np, false).unwrap();
+    let arr_f64 = PyArray::from_vec2(gil.python(), &vec2).unwrap();
+    let arr_i32: &PyArray<i32> = arr_f64.cast(py, false).unwrap();
     assert_eq!(
         arr_i32.as_array().unwrap(),
         array![[1, 2, 3], [1, 2, 3]].into_dyn()


### PR DESCRIPTION
and use static variable to access Numpy C APIs.
Since nowt we can't ensure operation's safety by `PyArrayModule`'s lifetime, I changed all APIs to return or take `&'py PyArray`.
TODO: 
- [x] comments
- [x] notes on README, that indicates really breaking change has done