### PR TITLE
Introduce ToNpyDims trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod npyffi;
 pub mod types;
 
 pub use array::{get_array_module, PyArray};
-pub use convert::IntoPyArray;
+pub use convert::{IntoPyArray, ToNpyDims};
 pub use error::*;
 pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use types::*;


### PR DESCRIPTION
So that we can use both &[2, 3] and [2, 3] to specify array dims