### PR TITLE
Remove some ToNpyDims implementation

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -126,7 +126,7 @@ impl<T> PyArray<T> {
     /// # extern crate pyo3; extern crate numpy; fn main() {
     /// use numpy::PyArray;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let arr = PyArray::<f64>::new(gil.python(), &[4, 5, 6]);
+    /// let arr = PyArray::<f64>::new(gil.python(), [4, 5, 6]);
     /// assert_eq!(arr.strides(), &[240, 48, 8]);
     /// # }
     /// ```
@@ -472,7 +472,7 @@ impl<T: TypeNum> PyArray<T> {
     /// use numpy::{PyArray, IntoPyArray};
     /// let gil = pyo3::Python::acquire_gil();
     /// let pyarray_f = PyArray::<f64>::arange(gil.python(), 2.0, 5.0, 1.0);
-    /// let pyarray_i = PyArray::<i64>::new(gil.python(), &[3]);
+    /// let pyarray_i = PyArray::<i64>::new(gil.python(), [3]);
     /// assert!(pyarray_f.copy_to(pyarray_i).is_ok());
     /// assert_eq!(pyarray_i.as_slice().unwrap(), &[2, 3, 4]);
     /// # }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -54,7 +54,7 @@ impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
             .collect();
         unsafe {
             let data = into_raw(self.into_raw_vec());
-            PyArray::new_(py, dims, strides.as_mut_ptr(), data)
+            PyArray::new_(py, &*dims, strides.as_mut_ptr(), data)
         }
     }
 }
@@ -115,26 +115,13 @@ macro_rules! array_dim_impls {
                     self
                 }
             }
-            impl<'a> ToNpyDims for &'a [usize; $N] {
-                fn dims_len(&self) -> c_int {
-                    $N as c_int
-                }
-                fn dims_ptr(&self) -> *mut npy_intp {
-                    self.as_ptr() as *mut npy_intp
-                }
-                fn dims_ref(&self) -> &[usize] {
-                    *self
-                }
-            }
         )+
     }
 }
 
 array_dim_impls! {
      0  1  2  3  4  5  6  7  8  9
-    10 11 12 13 14 15 16 17 18 19
-    20 21 22 23 24 25 26 27 28 29
-    30 31 32
+    10 11 12 13 14 15 16
 }
 
 impl<'a> ToNpyDims for &'a [usize] {
@@ -146,29 +133,5 @@ impl<'a> ToNpyDims for &'a [usize] {
     }
     fn dims_ref(&self) -> &[usize] {
         *self
-    }
-}
-
-impl ToNpyDims for Vec<usize> {
-    fn dims_len(&self) -> c_int {
-        self.len() as c_int
-    }
-    fn dims_ptr(&self) -> *mut npy_intp {
-        self.as_ptr() as *mut npy_intp
-    }
-    fn dims_ref(&self) -> &[usize] {
-        &*self
-    }
-}
-
-impl ToNpyDims for Box<[usize]> {
-    fn dims_len(&self) -> c_int {
-        self.len() as c_int
-    }
-    fn dims_ptr(&self) -> *mut npy_intp {
-        self.as_ptr() as *mut npy_intp
-    }
-    fn dims_ref(&self) -> &[usize] {
-        &*self
     }
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -11,7 +11,8 @@ fn new() {
     let gil = pyo3::Python::acquire_gil();
     let n = 3;
     let m = 5;
-    let arr = PyArray::<f64>::new(gil.python(), &[n, m]);
+    let dim = [n, m];
+    let arr = PyArray::<f64>::new(gil.python(), dim);
     assert!(arr.ndim() == 2);
     assert!(arr.dims() == [n, m]);
     assert!(arr.strides() == [m as isize * 8, 8]);
@@ -22,12 +23,12 @@ fn zeros() {
     let gil = pyo3::Python::acquire_gil();
     let n = 3;
     let m = 5;
-    let arr = PyArray::<f64>::zeros(gil.python(), &[n, m], false);
+    let arr = PyArray::<f64>::zeros(gil.python(), [n, m], false);
     assert!(arr.ndim() == 2);
     assert!(arr.dims() == [n, m]);
     assert!(arr.strides() == [m as isize * 8, 8]);
 
-    let arr = PyArray::<f64>::zeros(gil.python(), &[n, m], true);
+    let arr = PyArray::<f64>::zeros(gil.python(), [n, m], true);
     assert!(arr.ndim() == 2);
     assert!(arr.dims() == [n, m]);
     assert!(arr.strides() == [8, n as isize * 8]);
@@ -45,7 +46,7 @@ fn arange() {
 #[test]
 fn as_array() {
     let gil = pyo3::Python::acquire_gil();
-    let arr = PyArray::<f64>::zeros(gil.python(), &[3, 2, 4], false);
+    let arr = PyArray::<f64>::zeros(gil.python(), [3, 2, 4], false);
     let a = arr.as_array().unwrap();
     assert_eq!(arr.shape(), a.shape());
     assert_eq!(
@@ -95,7 +96,7 @@ fn iter_to_pyarray() {
 fn is_instance() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();
-    let arr = PyArray::<f64>::new(gil.python(), &[3, 5]);
+    let arr = PyArray::<f64>::new(gil.python(), [3, 5]);
     assert!(py.is_instance::<PyArray<f64>, _>(arr).unwrap());
     assert!(!py.is_instance::<pyo3::PyList, _>(arr).unwrap());
 }


### PR DESCRIPTION
We should treat only &[usize] or [usize; N] as dimension