### PR TITLE
[Experimental] Change all APIs to return owned type

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -23,12 +23,12 @@ use super::*;
 /// ```
 pub trait IntoPyArray {
     type Item: TypeNum;
-    fn into_pyarray(self, Python) -> &PyArray<Self::Item>;
+    fn into_pyarray(self, Python) -> PyArray<Self::Item>;
 }
 
 impl<T: TypeNum> IntoPyArray for Box<[T]> {
     type Item = T;
-    fn into_pyarray(self, py: Python) -> &PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
         let dims = [self.len()];
         let ptr = Box::into_raw(self);
         unsafe { PyArray::new_(py, dims, null_mut(), ptr as *mut c_void) }
@@ -37,7 +37,7 @@ impl<T: TypeNum> IntoPyArray for Box<[T]> {
 
 impl<T: TypeNum> IntoPyArray for Vec<T> {
     type Item = T;
-    fn into_pyarray(self, py: Python) -> &PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
         let dims = [self.len()];
         unsafe { PyArray::new_(py, dims, null_mut(), into_raw(self)) }
     }
@@ -45,7 +45,7 @@ impl<T: TypeNum> IntoPyArray for Vec<T> {
 
 impl<A: TypeNum, D: Dimension> IntoPyArray for Array<A, D> {
     type Item = A;
-    fn into_pyarray(self, py: Python) -> &PyArray<Self::Item> {
+    fn into_pyarray(self, py: Python) -> PyArray<Self::Item> {
         let dims: Vec<_> = self.shape().iter().cloned().collect();
         let mut strides: Vec<_> = self
             .strides()
@@ -64,7 +64,7 @@ macro_rules! array_impls {
         $(
             impl<T: TypeNum> IntoPyArray for [T; $N] {
                 type Item = T;
-                fn into_pyarray(self, py: Python) -> &PyArray<T> {
+                fn into_pyarray(self, py: Python) -> PyArray<T> {
                     let dims = [$N];
                     let ptr = Box::into_raw(Box::new(self));
                     unsafe {


### PR DESCRIPTION
(Maybe, I'm still investigating) Calling `pyo3::Python::from_owned_ptr` in extension can cause massive memory leak...

@konstin @termoshtt 
Any idea?