### PR TITLE
Fixed dimension by PhantomData

### DIFF
--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,7 +3,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyResult, PyArray, ToPyArray};
+use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -20,7 +20,12 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // wrapper of `axpy`
     #[pyfn(m, "axpy")]
-    fn axpy_py(py: Python, a: f64, x: &PyArray<f64>, y: &PyArray<f64>) -> PyResult<PyArray<f64>> {
+    fn axpy_py(
+        py: Python,
+        a: f64,
+        x: &PyArrayDyn<f64>,
+        y: &PyArrayDyn<f64>,
+    ) -> PyResult<PyArrayDyn<f64>> {
         let x = x.as_array().into_pyresult("x must be f64 array")?;
         let y = y.as_array().into_pyresult("y must be f64 array")?;
         Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
@@ -28,7 +33,7 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
-    fn mult_py(_py: Python, a: f64, x: &PyArray<f64>) -> PyResult<()> {
+    fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
         let x = x.as_array_mut().into_pyresult("x must be f64 array")?;
         mult(a, x);
         Ok(())

--- a/src/array.rs
+++ b/src/array.rs
@@ -530,19 +530,35 @@ impl<T: TypeNum> PyArray<T, Ix1> {
                 if length >= capacity {
                     capacity *= 2;
                     array
-                        .resize_([capacity], 0, NPY_ORDER::NPY_ANYORDER)
+                        .resize(capacity)
                         .expect("PyArray::from_iter: Failed to allocate memory");
                 }
                 *array.uget_mut([i]) = item;
             }
         }
         if capacity > length {
-            array.resize_([length], 0, NPY_ORDER::NPY_ANYORDER).unwrap()
+            array.resize(length).unwrap()
         }
         array
     }
 
-    // TODO: expose?
+    /// Extends or trancates the length of 1 dimension PyArray.
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let pyarray = PyArray::arange(gil.python(), 0, 10, 1);
+    /// assert_eq!(pyarray.len(), 10);
+    /// pyarray.resize(100).unwrap();
+    /// assert_eq!(pyarray.len(), 100);
+    /// # }
+    /// ```
+    pub fn resize(&self, new_elems: usize) -> Result<(), ErrorKind> {
+        self.resize_([new_elems], 1, NPY_ORDER::NPY_ANYORDER)
+    }
+
     fn resize_<'py, D: IntoDimension>(
         &'py self,
         dims: D,

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,28 +14,35 @@ use error::{ErrorKind, IntoPyErr};
 use types::{NpyDataType, TypeNum, NPY_ORDER};
 
 /// Interface for [NumPy ndarray](https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html).
-pub struct PyArray<T>(PyObject, PhantomData<T>);
+pub struct PyArray<T, D>(PyObject, PhantomData<T>, PhantomData<D>);
+pub type PyArray1<T> = PyArray<T, Ix1>;
+pub type PyArray2<T> = PyArray<T, Ix2>;
+pub type PyArray3<T> = PyArray<T, Ix3>;
+pub type PyArray4<T> = PyArray<T, Ix4>;
+pub type PyArray5<T> = PyArray<T, Ix5>;
+pub type PyArray6<T> = PyArray<T, Ix6>;
+pub type PyArrayDyn<T> = PyArray<T, IxDyn>;
 
 pub fn get_array_module(py: Python) -> PyResult<&PyModule> {
     PyModule::import(py, npyffi::array::MOD_NAME)
 }
 
 pyobject_native_type_convert!(
-    PyArray<T>,
+    PyArray<T, D>,
     *npyffi::PY_ARRAY_API.get_type_object(npyffi::ArrayType::PyArray_Type),
     npyffi::PyArray_Check,
-    T
+    T, D
 );
 
-pyobject_native_type_named!(PyArray<T>, T);
+pyobject_native_type_named!(PyArray<T, D>, T, D);
 
-impl<'a, T> ::std::convert::From<&'a PyArray<T>> for &'a PyObjectRef {
-    fn from(ob: &'a PyArray<T>) -> Self {
-        unsafe { &*(ob as *const PyArray<T> as *const PyObjectRef) }
+impl<'a, T, D> ::std::convert::From<&'a PyArray<T, D>> for &'a PyObjectRef {
+    fn from(ob: &'a PyArray<T, D>) -> Self {
+        unsafe { &*(ob as *const PyArray<T, D> as *const PyObjectRef) }
     }
 }
 
-impl<'a, T: TypeNum> FromPyObject<'a> for &'a PyArray<T> {
+impl<'a, T: TypeNum, D: Dimension> FromPyObject<'a> for &'a PyArray<T, D> {
     // here we do type-check twice
     // 1. Checks if the object is PyArray
     // 2. Checks if the data type of the array is T
@@ -44,7 +51,17 @@ impl<'a, T: TypeNum> FromPyObject<'a> for &'a PyArray<T> {
             if npyffi::PyArray_Check(ob.as_ptr()) == 0 {
                 return Err(PyDowncastError.into());
             }
-            &*(ob as *const PyObjectRef as *const PyArray<T>)
+            if let Some(ndim) = D::NDIM {
+                let ptr = ob.as_ptr() as *mut npyffi::PyArrayObject;
+                if (*ptr).nd as usize != ndim {
+                    return Err(PyErr::new::<exc::TypeError, _>(format!(
+                        "specified dim was {}, but actual dim was {}",
+                        ndim,
+                        (*ptr).nd
+                    )));
+                }
+            }
+            &*(ob as *const PyObjectRef as *const PyArray<T, D>)
         };
         array
             .type_check()
@@ -53,13 +70,13 @@ impl<'a, T: TypeNum> FromPyObject<'a> for &'a PyArray<T> {
     }
 }
 
-impl<T> IntoPyObject for PyArray<T> {
+impl<T, D> IntoPyObject for PyArray<T, D> {
     fn into_object(self, _py: Python) -> PyObject {
         self.0
     }
 }
 
-impl<T> PyArray<T> {
+impl<T, D> PyArray<T, D> {
     /// Gets a raw `PyArrayObject` pointer.
     pub fn as_array_ptr(&self) -> *mut npyffi::PyArrayObject {
         self.as_ptr() as _
@@ -78,10 +95,10 @@ impl<T> PyArray<T> {
     /// ```
     /// # extern crate pyo3; extern crate numpy; fn main() {
     /// use pyo3::{GILGuard, Python};
-    /// use numpy::PyArray;
-    /// fn return_py_array() -> PyArray<i32> {
+    /// use numpy::PyArray1;
+    /// fn return_py_array() -> PyArray1<i32> {
     ///    let gil = Python::acquire_gil();
-    ///    let array = PyArray::zeros(gil.python(), [5], false);
+    ///    let array = PyArray1::zeros(gil.python(), [5], false);
     ///    array.to_owned(gil.python())
     /// }
     /// let array = return_py_array();
@@ -90,7 +107,7 @@ impl<T> PyArray<T> {
     /// ```
     pub fn to_owned(&self, py: Python) -> Self {
         let obj = unsafe { PyObject::from_borrowed_ptr(py, self.as_ptr()) };
-        PyArray(obj, PhantomData)
+        PyArray(obj, PhantomData, PhantomData)
     }
 
     /// Constructs `PyArray` from raw python object without incrementing reference counts.
@@ -100,7 +117,7 @@ impl<T> PyArray<T> {
 
     /// Constructs PyArray from raw python object and increments reference counts.
     pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> &Self {
-        py.from_owned_ptr(ptr)
+        py.from_borrowed_ptr(ptr)
     }
 
     /// Returns the number of dimensions in the array.
@@ -110,9 +127,9 @@ impl<T> PyArray<T> {
     /// # Example
     /// ```
     /// # extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::PyArray;
+    /// use numpy::PyArray3;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let arr = PyArray::<f64>::new(gil.python(), [4, 5, 6], false);
+    /// let arr = PyArray3::<f64>::new(gil.python(), [4, 5, 6], false);
     /// assert_eq!(arr.ndim(), 3);
     /// # }
     /// ```
@@ -128,9 +145,9 @@ impl<T> PyArray<T> {
     /// # Example
     /// ```
     /// # extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::PyArray;
+    /// use numpy::PyArray3;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let arr = PyArray::<f64>::new(gil.python(), [4, 5, 6], false);
+    /// let arr = PyArray3::<f64>::new(gil.python(), [4, 5, 6], false);
     /// assert_eq!(arr.strides(), &[240, 48, 8]);
     /// # }
     /// ```
@@ -150,9 +167,9 @@ impl<T> PyArray<T> {
     /// # Example
     /// ```
     /// # extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::PyArray;
+    /// use numpy::PyArray3;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let arr = PyArray::<f64>::new(gil.python(), [4, 5, 6], false);
+    /// let arr = PyArray3::<f64>::new(gil.python(), [4, 5, 6], false);
     /// assert_eq!(arr.shape(), &[4, 5, 6]);
     /// # }
     /// ```
@@ -166,26 +183,9 @@ impl<T> PyArray<T> {
         }
     }
 
-    /// Same as [shape](#method.shape)
-    #[inline(always)]
-    pub fn dims(&self) -> &[usize] {
-        self.shape()
-    }
-
     /// Calcurates the total number of elements in the array.
     pub fn len(&self) -> usize {
         self.shape().iter().fold(1, |a, b| a * b)
-    }
-
-    fn ndarray_shape(&self) -> StrideShape<IxDyn> {
-        // FIXME may be done more simply
-        let shape: Shape<_> = Dim(self.shape()).into();
-        let st: Vec<usize> = self
-            .strides()
-            .iter()
-            .map(|&x| x as usize / ::std::mem::size_of::<T>())
-            .collect();
-        shape.strides(Dim(st))
     }
 
     fn typenum(&self) -> i32 {
@@ -199,6 +199,164 @@ impl<T> PyArray<T> {
     unsafe fn data(&self) -> *mut T {
         let ptr = self.as_array_ptr();
         (*ptr).data as *mut T
+    }
+}
+
+impl<T: TypeNum, D: Dimension> PyArray<T, D> {
+    /// Same as [shape](#method.shape), but returns `D`
+    #[inline(always)]
+    pub fn dims(&self) -> D {
+        D::from_dimension(&Dim(self.shape())).expect("PyArray::dims different dimension")
+    }
+
+    fn ndarray_shape(&self) -> StrideShape<D> {
+        // FIXME may be done more simply
+        let shape: Shape<_> = Dim(self.dims()).into();
+        let mut st = D::default();
+        let size = mem::size_of::<T>();
+        for (i, &s) in self.strides().iter().enumerate() {
+            st[i] = s as usize / size;
+        }
+        shape.strides(st)
+    }
+
+    /// Creates a new uninitialized PyArray in python heap.
+    ///
+    /// If `is_fortran == true`, returns Fortran-order array. Else, returns C-order array.
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; #[macro_use] extern crate ndarray; fn main() {
+    /// use numpy::PyArray3;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let pyarray = PyArray3::<i32>::new(gil.python(), [4, 5, 6], false);
+    /// assert_eq!(pyarray.shape(), &[4, 5, 6]);
+    /// # }
+    /// ```
+    pub fn new<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &'py Self
+    where
+        ID: IntoDimension<Dim = D>,
+    {
+        let flags = if is_fortran { 1 } else { 0 };
+        unsafe { PyArray::new_(py, dims, ptr::null_mut(), flags) }
+    }
+
+    unsafe fn new_<'py, ID>(
+        py: Python<'py>,
+        dims: ID,
+        strides: *mut npy_intp,
+        flag: c_int,
+    ) -> &'py Self
+    where
+        ID: IntoDimension<Dim = D>,
+    {
+        let dims = dims.into_dimension();
+        let ptr = PY_ARRAY_API.PyArray_New(
+            PY_ARRAY_API.get_type_object(npyffi::ArrayType::PyArray_Type),
+            dims.ndim_cint(),
+            dims.as_dims_ptr(),
+            T::typenum_default(),
+            strides,                // strides
+            ptr::null_mut(),        // data
+            0,                      // itemsize
+            flag,                   // flag
+            ::std::ptr::null_mut(), //obj
+        );
+        Self::from_owned_ptr(py, ptr)
+    }
+
+    /// Construct a new nd-dimensional array filled with 0.
+    ///
+    /// If `is_fortran` is true, then
+    /// a fortran order array is created, otherwise a C-order array is created.
+    ///
+    /// See also [PyArray_Zeros](https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_Zeros)
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; #[macro_use] extern crate ndarray; fn main() {
+    /// use numpy::PyArray2;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let pyarray = PyArray2::zeros(gil.python(), [2, 2], false);
+    /// assert_eq!(pyarray.as_array().unwrap(), array![[0, 0], [0, 0]]);
+    /// # }
+    /// ```
+    pub fn zeros<'py, ID>(py: Python<'py>, dims: ID, is_fortran: bool) -> &'py Self
+    where
+        ID: IntoDimension<Dim = D>,
+    {
+        let dims = dims.into_dimension();
+        unsafe {
+            let descr = PY_ARRAY_API.PyArray_DescrFromType(T::typenum_default());
+            let ptr = PY_ARRAY_API.PyArray_Zeros(
+                dims.ndim_cint(),
+                dims.as_dims_ptr(),
+                descr,
+                if is_fortran { -1 } else { 0 },
+            );
+            Self::from_owned_ptr(py, ptr)
+        }
+    }
+
+    /// Construct PyArray from ndarray::Array.
+    ///
+    /// This method allocates memory in Python's heap via numpy api, and then copies all elements
+    /// of the array there.
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate pyo3; extern crate numpy; #[macro_use] extern crate ndarray; fn main() {
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let pyarray = PyArray::from_ndarray(gil.python(), &array![[1, 2], [3, 4]]);
+    /// assert_eq!(pyarray.as_array().unwrap(), array![[1, 2], [3, 4]]);
+    /// # }
+    /// ```
+    pub fn from_ndarray<'py, S>(py: Python<'py>, arr: &ArrayBase<S, D>) -> &'py Self
+    where
+        S: Data<Elem = T>,
+    {
+        let len = arr.len();
+        let mut strides: Vec<_> = arr
+            .strides()
+            .into_iter()
+            .map(|n| n * mem::size_of::<T>() as npy_intp)
+            .collect();
+        unsafe {
+            let array = PyArray::new_(py, arr.raw_dim(), strides.as_mut_ptr() as *mut npy_intp, 0);
+            ptr::copy_nonoverlapping(arr.as_ptr(), array.data(), len);
+            array
+        }
+    }
+
+    /// Get the immutable view of the internal data of `PyArray`, as `ndarray::ArrayView`.
+    ///
+    /// # Example
+    /// ```
+    /// # #[macro_use] extern crate ndarray; extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let py_array = PyArray::arange(gil.python(), 0, 4, 1).reshape([2, 2]).unwrap();
+    /// assert_eq!(
+    ///     py_array.as_array().unwrap(),
+    ///     array![[0, 1], [2, 3]]
+    /// )
+    /// # }
+    /// ```
+    pub fn as_array(&self) -> Result<ArrayView<T, D>, ErrorKind> {
+        self.type_check()?;
+        unsafe { Ok(ArrayView::from_shape_ptr(self.ndarray_shape(), self.data())) }
+    }
+
+    /// Get the mmutable view of the internal data of `PyArray`, as `ndarray::ArrayViewMut`.
+    pub fn as_array_mut(&self) -> Result<ArrayViewMut<T, D>, ErrorKind> {
+        self.type_check()?;
+        unsafe {
+            Ok(ArrayViewMut::from_shape_ptr(
+                self.ndarray_shape(),
+                self.data(),
+            ))
+        }
     }
 
     /// Get an immutable reference of a specified element, without checking the
@@ -216,19 +374,43 @@ impl<T> PyArray<T> {
     /// let arr = PyArray::arange(gil.python(), 0, 16, 1).reshape([2, 2, 4]).unwrap();
     /// assert_eq!(*arr.get([1, 0, 3]).unwrap(), 11);
     /// assert!(arr.get([2, 0, 3]).is_none());
-    /// assert!(arr.get([1, 0, 3, 4]).is_none());
-    /// assert!(arr.get([1, 0]).is_none());
+    /// # }
+    /// ```
+    ///
+    /// For fixed dimension arrays, too long/short index causes compile error.
+    /// ```compile_fail
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let arr = PyArray::arange(gil.python(), 0, 16, 1).reshape([2, 2, 4]).unwrap();
+    /// let a = arr.get([1, 2]); // Compile Error!
+    /// # }
+    /// ```
+    /// But, for dinamic errors too long/short index returns `None`.
+    /// ```compile_fail
+    /// # extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let arr = PyArray::arange(gil.python(), 0, 16, 1).reshape([2, 2, 4]).unwrap();
+    /// let arr = arr.into_dyn();
+    /// assert!(arr.get([1, 2]).is_none());
     /// # }
     /// ```
     #[inline(always)]
-    pub fn get<Idx: NpyIndex>(&self, index: Idx) -> Option<&T> {
+    pub fn get<Idx>(&self, index: Idx) -> Option<&T>
+    where
+        Idx: NpyIndex<Dim = D>,
+    {
         let offset = index.get_checked::<T>(self.shape(), self.strides())?;
         unsafe { Some(&*self.data().offset(offset)) }
     }
 
     /// Same as [get](#method.get), but returns `&mut T`.
     #[inline(always)]
-    pub fn get_mut<Idx: NpyIndex>(&self, index: Idx) -> Option<&mut T> {
+    pub fn get_mut<Idx>(&self, index: Idx) -> Option<&mut T>
+    where
+        Idx: NpyIndex<Dim = D>,
+    {
         let offset = index.get_checked::<T>(self.shape(), self.strides())?;
         unsafe { Some(&mut *(self.data().offset(offset) as *mut T)) }
     }
@@ -250,20 +432,34 @@ impl<T> PyArray<T> {
     /// # }
     /// ```
     #[inline(always)]
-    pub unsafe fn uget<Idx: NpyIndex>(&self, index: Idx) -> &T {
+    pub unsafe fn uget<Idx>(&self, index: Idx) -> &T
+    where
+        Idx: NpyIndex<Dim = D>,
+    {
         let offset = index.get_unchecked::<T>(self.strides());
         &*self.data().offset(offset)
     }
 
     /// Same as [uget](#method.uget), but returns `&mut T`.
     #[inline(always)]
-    pub unsafe fn uget_mut<Idx: NpyIndex>(&self, index: Idx) -> &mut T {
+    pub unsafe fn uget_mut<Idx>(&self, index: Idx) -> &mut T
+    where
+        Idx: NpyIndex<Dim = D>,
+    {
         let offset = index.get_unchecked::<T>(self.strides());
         &mut *(self.data().offset(offset) as *mut T)
     }
+
+    /// Get dynamic dimensioned array from fixed dimension array.
+    ///
+    /// See [get](#method.get) for usage.
+    pub fn into_dyn(&self) -> &PyArray<T, IxDyn> {
+        let python = self.py();
+        unsafe { PyArray::from_borrowed_ptr(python, self.as_ptr()) }
+    }
 }
 
-impl<T: TypeNum> PyArray<T> {
+impl<T: TypeNum> PyArray<T, Ix1> {
     /// Construct one-dimension PyArray from slice.
     ///
     /// # Example
@@ -346,6 +542,32 @@ impl<T: TypeNum> PyArray<T> {
         array
     }
 
+    // TODO: expose?
+    fn resize_<'py, D: IntoDimension>(
+        &'py self,
+        dims: D,
+        check_ref: c_int,
+        order: NPY_ORDER,
+    ) -> Result<(), ErrorKind> {
+        let dims = dims.into_dimension();
+        let mut np_dims = dims.to_npy_dims();
+        let res = unsafe {
+            PY_ARRAY_API.PyArray_Resize(
+                self.as_array_ptr(),
+                &mut np_dims as *mut npyffi::PyArray_Dims,
+                check_ref,
+                order,
+            )
+        };
+        if res.is_null() {
+            Err(ErrorKind::dims_cast(self, dims))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<T: TypeNum> PyArray<T, Ix2> {
     /// Construct a two-dimension PyArray from `Vec<Vec<T>>`.
     ///
     /// This function checks all dimension of inner vec, and if there's any vec
@@ -358,7 +580,7 @@ impl<T: TypeNum> PyArray<T> {
     /// let gil = pyo3::Python::acquire_gil();
     /// let vec2 = vec![vec![1, 2, 3]; 2];
     /// let pyarray = PyArray::from_vec2(gil.python(), &vec2).unwrap();
-    /// assert_eq!(pyarray.as_array().unwrap(), array![[1, 2, 3], [1, 2, 3]].into_dyn());
+    /// assert_eq!(pyarray.as_array().unwrap(), array![[1, 2, 3], [1, 2, 3]]);
     /// assert!(PyArray::from_vec2(gil.python(), &vec![vec![1], vec![2, 3]]).is_err());
     /// # }
     /// ```
@@ -384,7 +606,9 @@ impl<T: TypeNum> PyArray<T> {
         }
         Ok(array)
     }
+}
 
+impl<T: TypeNum> PyArray<T, Ix3> {
     /// Construct a three-dimension PyArray from `Vec<Vec<Vec<T>>>`.
     ///
     /// This function checks all dimension of inner vec, and if there's any vec
@@ -399,15 +623,12 @@ impl<T: TypeNum> PyArray<T> {
     /// let pyarray = PyArray::from_vec3(gil.python(), &vec2).unwrap();
     /// assert_eq!(
     ///     pyarray.as_array().unwrap(),
-    ///     array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]].into_dyn()
+    ///     array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]]
     /// );
     /// assert!(PyArray::from_vec3(gil.python(), &vec![vec![vec![1], vec![]]]).is_err());
     /// # }
     /// ```
-    pub fn from_vec3<'py>(
-        py: Python<'py>,
-        v: &Vec<Vec<Vec<T>>>,
-    ) -> Result<&'py PyArray<T>, ErrorKind>
+    pub fn from_vec3<'py>(py: Python<'py>, v: &Vec<Vec<Vec<T>>>) -> Result<&'py Self, ErrorKind>
     where
         T: Clone,
     {
@@ -438,39 +659,9 @@ impl<T: TypeNum> PyArray<T> {
         }
         Ok(array)
     }
+}
 
-    /// Construct PyArray from ndarray::Array.
-    ///
-    /// This method allocates memory in Python's heap via numpy api, and then copies all elements
-    /// of the array there.
-    ///
-    /// # Example
-    /// ```
-    /// # extern crate pyo3; extern crate numpy; #[macro_use] extern crate ndarray; fn main() {
-    /// use numpy::PyArray;
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray = PyArray::from_ndarray(gil.python(), &array![[1, 2], [3, 4]]);
-    /// assert_eq!(pyarray.as_array().unwrap(), array![[1, 2], [3, 4]].into_dyn());
-    /// # }
-    /// ```
-    pub fn from_ndarray<'py, S, D>(py: Python<'py>, arr: &ArrayBase<S, D>) -> &'py Self
-    where
-        S: Data<Elem = T>,
-        D: Dimension,
-    {
-        let len = arr.len();
-        let mut strides: Vec<_> = arr
-            .strides()
-            .into_iter()
-            .map(|n| n * mem::size_of::<T>() as npy_intp)
-            .collect();
-        unsafe {
-            let array = PyArray::new_(py, arr.shape(), strides.as_mut_ptr() as *mut npy_intp, 0);
-            ptr::copy_nonoverlapping(arr.as_ptr(), array.data(), len);
-            array
-        }
-    }
-
+impl<T: TypeNum, D> PyArray<T, D> {
     /// Returns the scalar type of the array.
     pub fn data_type(&self) -> NpyDataType {
         NpyDataType::from_i32(self.typenum())
@@ -482,36 +673,6 @@ impl<T: TypeNum> PyArray<T> {
             Ok(())
         } else {
             Err(ErrorKind::to_rust(truth, T::npy_data_type()))
-        }
-    }
-
-    /// Get the immutable view of the internal data of `PyArray`, as `ndarray::ArrayView`.
-    ///
-    /// # Example
-    /// ```
-    /// # #[macro_use] extern crate ndarray; extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::PyArray;
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let py_array = PyArray::arange(gil.python(), 0, 4, 1).reshape([2, 2]).unwrap();
-    /// assert_eq!(
-    ///     py_array.as_array().unwrap(),
-    ///     array![[0, 1], [2, 3]].into_dyn()
-    /// )
-    /// # }
-    /// ```
-    pub fn as_array(&self) -> Result<ArrayViewD<T>, ErrorKind> {
-        self.type_check()?;
-        unsafe { Ok(ArrayView::from_shape_ptr(self.ndarray_shape(), self.data())) }
-    }
-
-    /// Get the mmutable view of the internal data of `PyArray`, as `ndarray::ArrayViewMut`.
-    pub fn as_array_mut(&self) -> Result<ArrayViewMutD<T>, ErrorKind> {
-        self.type_check()?;
-        unsafe {
-            Ok(ArrayViewMut::from_shape_ptr(
-                self.ndarray_shape(),
-                self.data(),
-            ))
         }
     }
 
@@ -536,87 +697,18 @@ impl<T: TypeNum> PyArray<T> {
         unsafe { Ok(::std::slice::from_raw_parts_mut(self.data(), self.len())) }
     }
 
-    /// Creates a new uninitialized PyArray in python heap.
-    ///
-    /// If `is_fortran == true`, returns Fortran-order array. Else, returns C-order array.
-    ///
-    /// # Example
-    /// ```
-    /// # extern crate pyo3; extern crate numpy; #[macro_use] extern crate ndarray; fn main() {
-    /// use numpy::PyArray;
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray = PyArray::<i32>::new(gil.python(), [4, 5, 6], false);
-    /// assert_eq!(pyarray.shape(), &[4, 5, 6]);
-    /// # }
-    /// ```
-    pub fn new<'py, D: IntoDimension>(py: Python<'py>, dims: D, is_fortran: bool) -> &'py Self {
-        let flags = if is_fortran { 1 } else { 0 };
-        unsafe { PyArray::new_(py, dims, ptr::null_mut(), flags) }
-    }
-
-    unsafe fn new_<'py, D: IntoDimension>(
-        py: Python<'py>,
-        dims: D,
-        strides: *mut npy_intp,
-        flag: c_int,
-    ) -> &'py Self {
-        let dims = dims.into_dimension();
-        let ptr = PY_ARRAY_API.PyArray_New(
-            PY_ARRAY_API.get_type_object(npyffi::ArrayType::PyArray_Type),
-            dims.ndim_cint(),
-            dims.as_dims_ptr(),
-            T::typenum_default(),
-            strides,                // strides
-            ptr::null_mut(),        // data
-            0,                      // itemsize
-            flag,                   // flag
-            ::std::ptr::null_mut(), //obj
-        );
-        Self::from_owned_ptr(py, ptr)
-    }
-
-    /// Construct a new nd-dimensional array filled with 0.
-    ///
-    /// If `is_fortran` is true, then
-    /// a fortran order array is created, otherwise a C-order array is created.
-    ///
-    /// See also [PyArray_Zeros](https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_Zeros)
-    ///
-    /// # Example
-    /// ```
-    /// # extern crate pyo3; extern crate numpy; #[macro_use] extern crate ndarray; fn main() {
-    /// use numpy::PyArray;
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray = PyArray::zeros(gil.python(), [2, 2], false);
-    /// assert_eq!(pyarray.as_array().unwrap(), array![[0, 0], [0, 0]].into_dyn());
-    /// # }
-    /// ```
-    pub fn zeros<'py, D: IntoDimension>(py: Python<'py>, dims: D, is_fortran: bool) -> &'py Self {
-        let dims = dims.into_dimension();
-        unsafe {
-            let descr = PY_ARRAY_API.PyArray_DescrFromType(T::typenum_default());
-            let ptr = PY_ARRAY_API.PyArray_Zeros(
-                dims.ndim_cint(),
-                dims.as_dims_ptr(),
-                descr,
-                if is_fortran { -1 } else { 0 },
-            );
-            Self::from_owned_ptr(py, ptr)
-        }
-    }
-
     /// Copies self into `other`, performing a data-type conversion if necessary.
     /// # Example
     /// ```
     /// # extern crate pyo3; extern crate numpy; fn main() {
     /// use numpy::PyArray;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray_f = PyArray::<f64>::arange(gil.python(), 2.0, 5.0, 1.0);
-    /// let pyarray_i = PyArray::<i64>::new(gil.python(), [3], false);
+    /// let pyarray_f = PyArray::arange(gil.python(), 2.0, 5.0, 1.0);
+    /// let pyarray_i = PyArray::<i64, _>::new(gil.python(), [3], false);
     /// assert!(pyarray_f.copy_to(pyarray_i).is_ok());
     /// assert_eq!(pyarray_i.as_slice().unwrap(), &[2, 3, 4]);
     /// # }
-    pub fn copy_to<U: TypeNum>(&self, other: &PyArray<U>) -> Result<(), ErrorKind> {
+    pub fn copy_to<U: TypeNum>(&self, other: &PyArray<U, D>) -> Result<(), ErrorKind> {
         let self_ptr = self.as_array_ptr();
         let other_ptr = other.as_array_ptr();
         let result = unsafe { PY_ARRAY_API.PyArray_CopyInto(other_ptr, self_ptr) };
@@ -633,12 +725,12 @@ impl<T: TypeNum> PyArray<T> {
     /// # extern crate pyo3; extern crate numpy; fn main() {
     /// use numpy::PyArray;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray_f = PyArray::<f64>::arange(gil.python(), 2.0, 5.0, 1.0);
-    /// let pyarray_i = PyArray::<i64>::new(gil.python(), [3], false);
+    /// let pyarray_f = PyArray::arange(gil.python(), 2.0, 5.0, 1.0);
+    /// let pyarray_i = PyArray::<i64, _>::new(gil.python(), [3], false);
     /// assert!(pyarray_f.move_to(pyarray_i).is_ok());
     /// assert_eq!(pyarray_i.as_slice().unwrap(), &[2, 3, 4]);
     /// # }
-    pub fn move_to<U: TypeNum>(&self, other: &PyArray<U>) -> Result<(), ErrorKind> {
+    pub fn move_to<U: TypeNum>(&self, other: &PyArray<U, D>) -> Result<(), ErrorKind> {
         let self_ptr = self.as_array_ptr();
         let other_ptr = other.as_array_ptr();
         let result = unsafe { PY_ARRAY_API.PyArray_MoveInto(other_ptr, self_ptr) };
@@ -655,14 +747,14 @@ impl<T: TypeNum> PyArray<T> {
     /// # extern crate pyo3; extern crate numpy; fn main() {
     /// use numpy::PyArray;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray_f = PyArray::<f64>::arange(gil.python(), 2.0, 5.0, 1.0);
+    /// let pyarray_f = PyArray::arange(gil.python(), 2.0, 5.0, 1.0);
     /// let pyarray_i = pyarray_f.cast::<i32>(false).unwrap();
     /// assert_eq!(pyarray_i.as_slice().unwrap(), &[2, 3, 4]);
     /// # }
     pub fn cast<'py, U: TypeNum>(
         &'py self,
         is_fortran: bool,
-    ) -> Result<&'py PyArray<U>, ErrorKind> {
+    ) -> Result<&'py PyArray<U, D>, ErrorKind> {
         let ptr = unsafe {
             let descr = PY_ARRAY_API.PyArray_DescrFromType(U::typenum_default());
             PY_ARRAY_API.PyArray_CastToType(
@@ -674,7 +766,7 @@ impl<T: TypeNum> PyArray<T> {
         if ptr.is_null() {
             Err(ErrorKind::dtype_cast(self, U::npy_data_type()))
         } else {
-            Ok(unsafe { PyArray::<U>::from_owned_ptr(self.py(), ptr) })
+            Ok(unsafe { PyArray::<U, D>::from_owned_ptr(self.py(), ptr) })
         }
     }
 
@@ -692,21 +784,29 @@ impl<T: TypeNum> PyArray<T> {
     /// let gil = pyo3::Python::acquire_gil();
     /// let array = PyArray::from_exact_iter(gil.python(), 0..9);
     /// let array = array.reshape([3, 3]).unwrap();
-    /// assert_eq!(array.as_array().unwrap(), array![[0, 1, 2], [3, 4, 5], [6, 7, 8]].into_dyn());
+    /// assert_eq!(array.as_array().unwrap(), array![[0, 1, 2], [3, 4, 5], [6, 7, 8]]);
     /// assert!(array.reshape([5]).is_err());
     /// # }
     /// ```
     #[inline(always)]
-    pub fn reshape<'py, D: IntoDimension>(&'py self, dims: D) -> Result<&Self, ErrorKind> {
+    pub fn reshape<'py, ID, D2>(&'py self, dims: ID) -> Result<&'py PyArray<T, D2>, ErrorKind>
+    where
+        ID: IntoDimension<Dim = D2>,
+        D2: Dimension,
+    {
         self.reshape_with_order(dims, NPY_ORDER::NPY_ANYORDER)
     }
 
     /// Same as [reshape](method.reshape.html), but you can change the order of returned matrix.
-    pub fn reshape_with_order<'py, D: IntoDimension>(
+    pub fn reshape_with_order<'py, ID, D2>(
         &'py self,
-        dims: D,
+        dims: ID,
         order: NPY_ORDER,
-    ) -> Result<&Self, ErrorKind> {
+    ) -> Result<&'py PyArray<T, D2>, ErrorKind>
+    where
+        ID: IntoDimension<Dim = D2>,
+        D2: Dimension,
+    {
         let dims = dims.into_dimension();
         let mut np_dims = dims.to_npy_dims();
         let ptr = unsafe {
@@ -719,36 +819,12 @@ impl<T: TypeNum> PyArray<T> {
         if ptr.is_null() {
             Err(ErrorKind::dims_cast(self, dims))
         } else {
-            Ok(unsafe { PyArray::<T>::from_owned_ptr(self.py(), ptr) })
-        }
-    }
-
-    // TODO: expose?
-    fn resize_<'py, D: IntoDimension>(
-        &'py self,
-        dims: D,
-        check_ref: c_int,
-        order: NPY_ORDER,
-    ) -> Result<(), ErrorKind> {
-        let dims = dims.into_dimension();
-        let mut np_dims = dims.to_npy_dims();
-        let res = unsafe {
-            PY_ARRAY_API.PyArray_Resize(
-                self.as_array_ptr(),
-                &mut np_dims as *mut npyffi::PyArray_Dims,
-                check_ref,
-                order,
-            )
-        };
-        if res.is_null() {
-            Err(ErrorKind::dims_cast(self, dims))
-        } else {
-            Ok(())
+            Ok(unsafe { PyArray::<T, D2>::from_owned_ptr(self.py(), ptr) })
         }
     }
 }
 
-impl<T: TypeNum + AsPrimitive<f64>> PyArray<T> {
+impl<T: TypeNum + AsPrimitive<f64>> PyArray<T, Ix1> {
     /// Return evenly spaced values within a given interval.
     /// Same as [numpy.arange](https://docs.scipy.org/doc/numpy/reference/generated/numpy.arange.html).
     ///
@@ -759,9 +835,9 @@ impl<T: TypeNum + AsPrimitive<f64>> PyArray<T> {
     /// # extern crate pyo3; extern crate numpy; fn main() {
     /// use numpy::PyArray;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray = PyArray::<f64>::arange(gil.python(), 2.0, 4.0, 0.5);
+    /// let pyarray = PyArray::arange(gil.python(), 2.0, 4.0, 0.5);
     /// assert_eq!(pyarray.as_slice().unwrap(), &[2.0, 2.5, 3.0, 3.5]);
-    /// let pyarray = PyArray::<i32>::arange(gil.python(), -2, 4, 3);
+    /// let pyarray = PyArray::arange(gil.python(), -2, 4, 3);
     /// assert_eq!(pyarray.as_slice().unwrap(), &[-2, 1]);
     /// # }
     pub fn arange<'py>(py: Python<'py>, start: T, stop: T, step: T) -> &'py Self {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -53,8 +53,8 @@ pub trait ToNpyDims: Dimension {
     fn ndim_cint(&self) -> c_int {
         self.ndim() as c_int
     }
-    fn as_dims_ptr(&self) -> *mut npy_intp {
-        self.slice().as_ptr() as *mut npy_intp
+    fn as_dims_ptr(&self) -> *mut npyffi::npy_intp {
+        self.slice().as_ptr() as *mut npyffi::npy_intp
     }
     fn to_npy_dims(&self) -> npyffi::PyArray_Dims {
         npyffi::PyArray_Dims {
@@ -73,7 +73,8 @@ impl<D: Dimension> ToNpyDims for D {
 
 /// Types that can be used to index an array.
 ///
-/// See[IntoDimension](https://docs.rs/ndarray/0.12/ndarray/dimension/conversion/trait.IntoDimension.html)
+/// See
+/// [IntoDimension](https://docs.rs/ndarray/0.12/ndarray/dimension/conversion/trait.IntoDimension.html)
 /// for what types you can use as `NpyIndex`.
 ///
 /// But basically, you can use

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ impl ErrorKind {
             to,
         }
     }
-    pub(crate) fn dtype_cast<T: TypeNum>(from: &PyArray<T>, to: NpyDataType) -> Self {
+    pub(crate) fn dtype_cast<T: TypeNum, D>(from: &PyArray<T, D>, to: NpyDataType) -> Self {
         let dims = from
             .shape()
             .into_iter()
@@ -70,7 +70,7 @@ impl ErrorKind {
         let to = ArrayFormat { dims, dtype: to };
         ErrorKind::PyToPy(Box::new((from, to)))
     }
-    pub(crate) fn dims_cast<T: TypeNum>(from: &PyArray<T>, to_dim: impl ToNpyDims) -> Self {
+    pub(crate) fn dims_cast<T: TypeNum, D>(from: &PyArray<T, D>, to_dim: impl ToNpyDims) -> Self {
         let dims_from = from
             .shape()
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!     let py_array = array![[1i64, 2], [3, 4]].to_pyarray(py);
 //!     assert_eq!(
 //!         py_array.as_array().unwrap(),
-//!         array![[1i64, 2], [3, 4]].into_dyn(),
+//!         array![[1i64, 2], [3, 4]]
 //!     );
 //! }
 //! ```
@@ -43,7 +43,10 @@ pub mod error;
 pub mod npyffi;
 pub mod types;
 
-pub use array::{get_array_module, PyArray};
+pub use array::{
+    get_array_module, PyArray, PyArray1, PyArray2, PyArray3, PyArray4, PyArray5, PyArray6,
+    PyArrayDyn,
+};
 pub use convert::{NpyIndex, ToNpyDims, ToPyArray};
 pub use error::*;
 pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 //! installed by `pip install numpy` or other ways in your python environment.
 //! You can use both system environment and `virtualenv`.
 //!
+//! This library loads numpy module automatically. So if numpy is not installed, it simply panics,
+//! instead of returing a result.
+//!
 //! # Example
 //!
 //! ```
@@ -48,6 +51,7 @@ pub use array::{
     PyArrayDyn,
 };
 pub use convert::{NpyIndex, ToNpyDims, ToPyArray};
-pub use error::*;
+pub use error::{IntoPyErr, IntoPyResult, ArrayFormat, ErrorKind};
 pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};
-pub use types::*;
+pub use types::{c32, c64, NpyDataType, TypeNum};
+pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -24,7 +24,7 @@ const CAPSULE_NAME: &str = "_ARRAY_API";
 /// use numpy::{PyArray, npyffi::types::NPY_SORTKIND, PY_ARRAY_API};
 /// use pyo3::Python;
 /// let gil = Python::acquire_gil();
-/// let array: &PyArray<i32> = PyArray::arange(gil.python(), 2, 5, 1);
+/// let array = PyArray::arange(gil.python(), 2, 5, 1);
 /// array.as_slice_mut().unwrap().swap(0, 1);
 /// assert_eq!(array.as_slice().unwrap(), &[3, 2, 4]);
 /// unsafe {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,8 @@
 //! Implements conversion utitlities.
-
+/// alias of Complex32
 pub use num_complex::Complex32 as c32;
+/// alias of Complex64
 pub use num_complex::Complex64 as c64;
-
-pub use super::npyffi::npy_intp;
-pub use super::npyffi::NPY_ORDER;
-pub use super::npyffi::NPY_ORDER::{NPY_CORDER, NPY_FORTRANORDER};
 
 use super::npyffi::NPY_TYPES;
 


### PR DESCRIPTION
This PR changes `PyArray<T>` into `PyArray<T, D>`, where `D` represents the dimension, like ndarray does.

In [this comment](https://github.com/rust-numpy/rust-numpy/pull/41#issuecomment-408663714) I denied this approach, but when I added `get` methods in #68, I thought this idea good, to restrict invalid index.

## TODO
- [x] documentation