### PR TITLE
Refactor IntoPyErr

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ numpy = "0.3"
 ``` rust
 extern crate numpy;
 extern crate pyo3;
-use numpy::{IntoPyResult, PyArray1, get_array_module};
+use numpy::{PyArray1, get_array_module};
 use pyo3::prelude::{ObjectProtocol, PyDict, PyResult, Python};
 
 fn main() -> Result<(), ()> {
@@ -95,7 +95,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{PyArrayDyn, ToPyArray};
+use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
+use numpy::{PyArrayDyn, ToPyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -118,21 +118,22 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         x: &PyArrayDyn<f64>,
         y: &PyArrayDyn<f64>,
     ) -> PyResult<PyArrayDyn<f64>> {
-        let x = x.as_array().into_pyresult("x must be f64 array")?;
-        let y = y.as_array().into_pyresult("y must be f64 array")?;
+        let x = x.as_array()?;
+        let y = y.as_array()?;
         Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
     fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
-        let x = x.as_array_mut().into_pyresult("x must be f64 array")?;
+        let x = x.as_array_mut()?;
         mult(a, x);
         Ok(())
     }
 
     Ok(())
 }
+
 ```
 
 Contribution

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         x: &PyArrayDyn<f64>,
         y: &PyArrayDyn<f64>,
     ) -> PyResult<PyArrayDyn<f64>> {
+        // you can convert numpy error into PyErr via ?
         let x = x.as_array()?;
-        let y = y.as_array()?;
+        // you can also specify your error context, via closure
+        let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
         Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
     }
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn main_<'py>(py: Python<'py>) -> PyResult<()> {
     let pyarray: &PyArray1<i32> = py
         .eval("np.array([1, 2, 3], dtype='int32')", Some(&dict), None)?
         .extract()?;
-    let slice = pyarray.as_slice().into_pyresult("Array Cast failed")?;
+    let slice = pyarray.as_slice()?;
     assert_eq!(slice, &[1, 2, 3]);
     Ok(())
 }

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,7 +3,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
+use numpy::{PyArrayDyn, ToPyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -26,15 +26,15 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         x: &PyArrayDyn<f64>,
         y: &PyArrayDyn<f64>,
     ) -> PyResult<PyArrayDyn<f64>> {
-        let x = x.as_array().into_pyresult("x must be f64 array")?;
-        let y = y.as_array().into_pyresult("y must be f64 array")?;
+        let x = x.as_array()?;
+        let y = y.as_array()?;
         Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
     fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
-        let x = x.as_array_mut().into_pyresult("x must be f64 array")?;
+        let x = x.as_array_mut()?;
         mult(a, x);
         Ok(())
     }

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,7 +3,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{PyArrayDyn, ToPyArray};
+use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -26,8 +26,10 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         x: &PyArrayDyn<f64>,
         y: &PyArrayDyn<f64>,
     ) -> PyResult<PyArrayDyn<f64>> {
+        // you can convert numpy error into PyErr via ?
         let x = x.as_array()?;
-        let y = y.as_array()?;
+         // you can also specify your error context, via closure
+        let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
         Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -10,7 +10,7 @@ use std::os::raw::c_int;
 use std::ptr;
 
 use convert::{NpyIndex, ToNpyDims};
-use error::{ErrorKind, IntoPyErr};
+use error::{ErrorKind, IntoPyResult};
 use types::{NpyDataType, TypeNum};
 
 /// A safe, static-typed interface for
@@ -130,7 +130,7 @@ impl<'a, T: TypeNum, D: Dimension> FromPyObject<'a> for &'a PyArray<T, D> {
         array
             .type_check()
             .map(|_| array)
-            .map_err(|err| err.into_pyerr("FromPyObject::extract typecheck failed"))
+            .into_pyresult_with(|| "FromPyObject::extract typecheck failed")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use array::{
     PyArrayDyn,
 };
 pub use convert::{NpyIndex, ToNpyDims, ToPyArray};
-pub use error::{IntoPyErr, IntoPyResult, ArrayFormat, ErrorKind};
+pub use error::{ArrayFormat, ErrorKind, IntoPyErr, IntoPyResult};
+pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use types::{c32, c64, NpyDataType, TypeNum};
-pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};


### PR DESCRIPTION
Implement From<ErrorKind> for PyErr and now IntoPyErr is only for
passing message to Python