### PR TITLE
Fix experimental access to extern crates

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -175,12 +175,12 @@ impl<T, D> PyArray<T, D> {
     }
 
     /// Constructs `PyArray` from raw python object without incrementing reference counts.
-    pub unsafe fn from_owned_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> &Self {
+    pub unsafe fn from_owned_ptr(py: Python, ptr: *mut ffi::PyObject) -> &Self {
         py.from_owned_ptr(ptr)
     }
 
     /// Constructs PyArray from raw python object and increments reference counts.
-    pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> &Self {
+    pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut ffi::PyObject) -> &Self {
         py.from_borrowed_ptr(ptr)
     }
 


### PR DESCRIPTION
I can't compile the current code because of the following error:

```
error[E0658]: access to extern crates through prelude is experimental (see issue #44660)
   --> rust-numpy/src/array.rs:183:59
    |
183 |     pub unsafe fn from_borrowed_ptr(py: Python, ptr: *mut pyo3::ffi::PyObject) -> &Self {
    |                                                                                                         ^^^^
    |
    = help: add #![feature(extern_prelude)] to the crate attributes to enable
```

Tested with rustc 1.31.0-nightly (14f42a732 2018-10-14) and rustc 1.30.0-nightly (2d4e34ca8 2018-09-09).

Using ffi instead of pyo3::ffi is enough for fixing that.

(question: how does it work on Travis?)