### PR TITLE
Revive into_pyarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
+use numpy::{IntoPyArray, IntoPyResult, PyArrayDyn};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -122,7 +122,7 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         let x = x.as_array()?;
         // you can also specify your error context, via closure
         let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
-        Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
+        Ok(axpy(a, x, y).into_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`
@@ -135,7 +135,6 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
 
     Ok(())
 }
-
 ```
 
 Contribution

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,7 +3,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyArray, IntoPyResult, PyArray1, PyArrayDyn, ToPyArray};
+use numpy::{IntoPyArray, IntoPyResult, PyArrayDyn};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -30,7 +30,7 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         let x = x.as_array()?;
         // you can also specify your error context, via closure
         let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
-        Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
+        Ok(axpy(a, x, y).into_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`
@@ -41,15 +41,5 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         Ok(())
     }
 
-    #[pyfn(m, "get_vec")]
-    fn get_vec(py: Python, size: usize) -> PyResult<&PyArray1<f32>> {
-        Ok(vec![0.0; size].into_pyarray(py))
-    }
-    // use numpy::slice_box::SliceBox;
-    // #[pyfn(m, "get_slice")]
-    // fn get_slice(py: Python, size: usize) -> PyResult<SliceBox<f32>> {
-    //     let sbox = numpy::slice_box::SliceBox::new(vec![0.0; size].into_boxed_slice());
-    //     Ok(sbox)
-    // }
     Ok(())
 }

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,7 +3,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyResult, PyArrayDyn, ToPyArray};
+use numpy::{IntoPyArray, IntoPyResult, PyArray1, PyArrayDyn, ToPyArray};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -28,7 +28,7 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
     ) -> PyResult<PyArrayDyn<f64>> {
         // you can convert numpy error into PyErr via ?
         let x = x.as_array()?;
-         // you can also specify your error context, via closure
+        // you can also specify your error context, via closure
         let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
         Ok(axpy(a, x, y).to_pyarray(py).to_owned(py))
     }
@@ -41,5 +41,15 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         Ok(())
     }
 
+    #[pyfn(m, "get_vec")]
+    fn get_vec(py: Python, size: usize) -> PyResult<&PyArray1<f32>> {
+        Ok(vec![0.0; size].into_pyarray(py))
+    }
+    // use numpy::slice_box::SliceBox;
+    // #[pyfn(m, "get_slice")]
+    // fn get_slice(py: Python, size: usize) -> PyResult<SliceBox<f32>> {
+    //     let sbox = numpy::slice_box::SliceBox::new(vec![0.0; size].into_boxed_slice());
+    //     Ok(sbox)
+    // }
     Ok(())
 }

--- a/example/setup.py
+++ b/example/setup.py
@@ -10,14 +10,7 @@ from setuptools_rust import RustExtension
 class CmdTest(TestCommand):
     def run(self):
         self.run_command("test_rust")
-        test_files = os.listdir('./tests')
-        ok = 0
-        for f in test_files:
-            _, ext = os.path.splitext(f)
-            if ext == '.py':
-                res = subprocess.call([sys.executable, f], cwd='./tests')
-                ok = ok | res
-        sys.exit(res)
+        subprocess.check_call([sys.executable, 'test_ext.py'], cwd='./tests')
 
 
 setup_requires = ['setuptools-rust>=0.6.0']

--- a/example/tests/test_ext.py
+++ b/example/tests/test_ext.py
@@ -1,6 +1,7 @@
 import numpy as np
-from rust_ext import axpy, mult, get_vec
+from rust_ext import axpy, mult
 import unittest
+
 
 class TestExt(unittest.TestCase):
     """Test class for rust functions
@@ -11,18 +12,16 @@ class TestExt(unittest.TestCase):
         y = np.array([3.0, 3.0, 3.0])
         z = axpy(3.0, x, y)
         np.testing.assert_array_almost_equal(z, np.array([6.0, 9.0, 12.0]))
+        x = np.array([*x, 4.0])
+        y = np.array([*y, 3.0])
+        z = axpy(3.0, x, y)
+        np.testing.assert_array_almost_equal(z, np.array([6.0, 9.0, 12.0, 15.0]))
 
     def test_mult(self):
         x = np.array([1.0, 2.0, 3.0])
         mult(3.0, x)
         np.testing.assert_array_almost_equal(x, np.array([3.0, 6.0, 9.0]))
 
-    def test_into_pyarray(self):
-        x = get_vec(1000)
-        np.testing.assert_array_almost_equal(x, np.zeros(1000))
-
 
 if __name__ == "__main__":
     unittest.main()
-
-

--- a/example/tests/test_ext.py
+++ b/example/tests/test_ext.py
@@ -1,5 +1,5 @@
 import numpy as np
-from rust_ext import axpy, mult
+from rust_ext import axpy, mult, get_vec
 import unittest
 
 class TestExt(unittest.TestCase):
@@ -17,6 +17,12 @@ class TestExt(unittest.TestCase):
         mult(3.0, x)
         np.testing.assert_array_almost_equal(x, np.array([3.0, 6.0, 9.0]))
 
+    def test_into_pyarray(self):
+        x = get_vec(1000)
+        np.testing.assert_array_almost_equal(x, np.zeros(1000))
+
 
 if __name__ == "__main__":
     unittest.main()
+
+

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -14,13 +14,17 @@ use npyffi::npy_intp;
 ///
 /// This trait takes `self`, which means **it holds a pointer to Rust heap, until `resize` or other
 /// destructive method is called**.
+///
+/// In addition, if you construct `PyArray` via this method,
+/// **you cannot use some destructive methods like `resize`.**
 /// # Example
 /// ```
 /// # extern crate pyo3; extern crate numpy; fn main() {
-/// use numpy::{PyArray, ToPyArray};
+/// use numpy::{PyArray, IntoPyArray};
 /// let gil = pyo3::Python::acquire_gil();
-/// let py_array = vec![1, 2, 3].to_pyarray(gil.python());
+/// let py_array = vec![1, 2, 3].into_pyarray(gil.python());
 /// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
+/// assert!(py_array.resize(100).is_err()); // You can't resize owned-by-rust array.
 /// # }
 /// ```
 pub trait IntoPyArray {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,14 @@ pub mod array;
 pub mod convert;
 pub mod error;
 pub mod npyffi;
+mod slice_box;
 pub mod types;
 
 pub use array::{
     get_array_module, PyArray, PyArray1, PyArray2, PyArray3, PyArray4, PyArray5, PyArray6,
     PyArrayDyn,
 };
-pub use convert::{NpyIndex, ToNpyDims, ToPyArray};
+pub use convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 pub use error::{ArrayFormat, ErrorKind, IntoPyErr, IntoPyResult};
 pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 pub use npyffi::{PY_ARRAY_API, PY_UFUNC_API};

--- a/src/slice_box.rs
+++ b/src/slice_box.rs
@@ -1,0 +1,79 @@
+use crate::types::TypeNum;
+use pyo3::{self, ffi, typeob, PyObjectAlloc, Python, ToPyPointer};
+use std::os::raw::c_void;
+
+#[repr(C)]
+pub(crate) struct SliceBox<T> {
+    ob_base: ffi::PyObject,
+    inner: *mut [T],
+}
+
+impl<T> SliceBox<T> {
+    pub(crate) unsafe fn new<'a>(box_: Box<[T]>) -> &'a Self {
+        <Self as typeob::PyTypeObject>::init_type();
+        let type_ob = <Self as typeob::PyTypeInfo>::type_object() as *mut _;
+        let base = ffi::_PyObject_New(type_ob);
+        *base = ffi::PyObject_HEAD_INIT;
+        (*base).ob_type = <Self as typeob::PyTypeInfo>::type_object() as *mut _;
+        let self_ = base as *mut SliceBox<T>;
+        (*self_).inner = Box::into_raw(box_);
+        &*self_
+    }
+    pub(crate) fn data(&self) -> *mut c_void {
+        self.inner as *mut c_void
+    }
+}
+
+impl<T> typeob::PyTypeInfo for SliceBox<T> {
+    type Type = ();
+    type BaseType = pyo3::PyObjectRef;
+    const NAME: &'static str = "SliceBox";
+    const DESCRIPTION: &'static str = "Memory store for PyArray made by IntoPyArray.";
+    const FLAGS: usize = 0;
+    const SIZE: usize = { Self::OFFSET as usize + std::mem::size_of::<Self>() + 0 + 0 };
+    const OFFSET: isize = 0;
+    #[inline]
+    unsafe fn type_object() -> &'static mut ::pyo3::ffi::PyTypeObject {
+        static mut TYPE_OBJECT: ::pyo3::ffi::PyTypeObject = ::pyo3::ffi::PyTypeObject_INIT;
+        &mut TYPE_OBJECT
+    }
+}
+
+impl<T: TypeNum> typeob::PyTypeObject for SliceBox<T> {
+    #[inline(always)]
+    fn init_type() {
+        static START: std::sync::Once = std::sync::ONCE_INIT;
+        START.call_once(|| {
+            let ty = unsafe { <Self as typeob::PyTypeInfo>::type_object() };
+            if (ty.tp_flags & ffi::Py_TPFLAGS_READY) == 0 {
+                let gil = Python::acquire_gil();
+                let py = gil.python();
+                let mod_name = format!("rust_numpy.{:?}", T::npy_data_type());
+                typeob::initialize_type::<Self>(py, Some(&mod_name))
+                    .map_err(|e| e.print(py))
+                    .expect("Failed to initialize SliceBox");
+            }
+        });
+    }
+}
+
+impl<T> ToPyPointer for SliceBox<T> {
+    #[inline]
+    fn as_ptr(&self) -> *mut ffi::PyObject {
+        &self.ob_base as *const _ as *mut _
+    }
+}
+
+impl<T> PyObjectAlloc<SliceBox<T>> for SliceBox<T> {
+    /// Calls the rust destructor for the object.
+    unsafe fn drop(py: Python, obj: *mut ffi::PyObject) {
+        let data = (*(obj as *mut SliceBox<T>)).inner;
+        let box_ = Box::from_raw(data);
+        drop(box_);
+        <Self as typeob::PyTypeInfo>::BaseType::drop(py, obj);
+    }
+    unsafe fn dealloc(py: Python, obj: *mut ffi::PyObject) {
+        Self::drop(py, obj);
+        ffi::PyObject_Free(obj as *mut c_void);
+    }
+}

--- a/src/slice_box.rs
+++ b/src/slice_box.rs
@@ -68,8 +68,8 @@ impl<T> PyObjectAlloc<SliceBox<T>> for SliceBox<T> {
     /// Calls the rust destructor for the object.
     unsafe fn drop(py: Python, obj: *mut ffi::PyObject) {
         let data = (*(obj as *mut SliceBox<T>)).inner;
-        let box_ = Box::from_raw(data);
-        drop(box_);
+        let boxed_slice = Box::from_raw(data);
+        drop(boxed_slice);
         <Self as typeob::PyTypeInfo>::BaseType::drop(py, obj);
     }
     unsafe fn dealloc(py: Python, obj: *mut ffi::PyObject) {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -214,3 +214,14 @@ fn into_pyarray_vec() {
     let arr = a.into_pyarray(gil.python());
     assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
 }
+
+#[test]
+fn into_pyarray_array() {
+    let gil = pyo3::Python::acquire_gil();
+    let arr = Array3::<f64>::zeros((3, 4, 2));
+    let shape = arr.shape().iter().cloned().collect::<Vec<_>>();
+    let strides = arr.strides().iter().map(|d| d * 8).collect::<Vec<_>>();
+    let py_arr = arr.into_pyarray(gil.python());
+    assert_eq!(py_arr.shape(), shape.as_slice());
+    assert_eq!(py_arr.strides(), strides.as_slice());
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -75,7 +75,7 @@ fn as_array() {
 }
 
 #[test]
-fn into_pyarray_vec() {
+fn to_pyarray_vec() {
     let gil = pyo3::Python::acquire_gil();
 
     let a = vec![1, 2, 3];
@@ -86,7 +86,7 @@ fn into_pyarray_vec() {
 }
 
 #[test]
-fn into_pyarray_array() {
+fn to_pyarray_array() {
     let gil = pyo3::Python::acquire_gil();
 
     let a = Array3::<f64>::zeros((3, 4, 2));
@@ -205,4 +205,12 @@ fn array_cast() {
     let arr_f64 = PyArray::from_vec2(gil.python(), &vec2).unwrap();
     let arr_i32: &PyArray2<i32> = arr_f64.cast(false).unwrap();
     assert_eq!(arr_i32.as_array().unwrap(), array![[1, 2, 3], [1, 2, 3]]);
+}
+
+#[test]
+fn into_pyarray_vec() {
+    let gil = pyo3::Python::acquire_gil();
+    let a = vec![1, 2, 3];
+    let arr = a.into_pyarray(gil.python());
+    assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -225,3 +225,11 @@ fn into_pyarray_array() {
     assert_eq!(py_arr.shape(), shape.as_slice());
     assert_eq!(py_arr.strides(), strides.as_slice());
 }
+
+#[test]
+fn into_pyarray_cant_resize() {
+    let gil = pyo3::Python::acquire_gil();
+    let a = vec![1, 2, 3];
+    let arr = a.into_pyarray(gil.python());
+    assert!(arr.resize(100).is_err())
+}


### PR DESCRIPTION
This PR re-implements `IntoPyArray` trait, which was removed by #68.
To prevent memory leak, I set `SliceBox`(just a thin wrapper of slice) as a base type of array.

TODO:
- [x] refactor
- [x] impl for `Array<A, D>(ArrayBase<OwnedRepr<A>, D>)`
- [x] documentation
