### PR TITLE
Not return result in as_array & as_slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyArray, IntoPyResult, PyArrayDyn};
+use numpy::{IntoPyArray, PyArrayDyn};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -119,16 +119,16 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         y: &PyArrayDyn<f64>,
     ) -> PyResult<PyArrayDyn<f64>> {
         // you can convert numpy error into PyErr via ?
-        let x = x.as_array()?;
+        let x = x.as_array();
         // you can also specify your error context, via closure
-        let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
+        let y = y.as_array();
         Ok(axpy(a, x, y).into_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
     fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
-        let x = x.as_array_mut()?;
+        let x = x.as_array_mut();
         mult(a, x);
         Ok(())
     }

--- a/example/extensions/src/lib.rs
+++ b/example/extensions/src/lib.rs
@@ -3,7 +3,7 @@ extern crate numpy;
 extern crate pyo3;
 
 use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
-use numpy::{IntoPyArray, IntoPyResult, PyArrayDyn};
+use numpy::{IntoPyArray, PyArrayDyn};
 use pyo3::prelude::{pymodinit, PyModule, PyResult, Python};
 
 #[pymodinit]
@@ -27,16 +27,16 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
         y: &PyArrayDyn<f64>,
     ) -> PyResult<PyArrayDyn<f64>> {
         // you can convert numpy error into PyErr via ?
-        let x = x.as_array()?;
+        let x = x.as_array();
         // you can also specify your error context, via closure
-        let y = y.as_array().into_pyresult_with(|| "y must be f64 array")?;
+        let y = y.as_array();
         Ok(axpy(a, x, y).into_pyarray(py).to_owned(py))
     }
 
     // wrapper of `mult`
     #[pyfn(m, "mult")]
     fn mult_py(_py: Python, a: f64, x: &PyArrayDyn<f64>) -> PyResult<()> {
-        let x = x.as_array_mut()?;
+        let x = x.as_array_mut();
         mult(a, x);
         Ok(())
     }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -23,7 +23,7 @@ use npyffi::npy_intp;
 /// use numpy::{PyArray, IntoPyArray};
 /// let gil = pyo3::Python::acquire_gil();
 /// let py_array = vec![1, 2, 3].into_pyarray(gil.python());
-/// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
+/// assert_eq!(py_array.as_slice(), &[1, 2, 3]);
 /// assert!(py_array.resize(100).is_err()); // You can't resize owned-by-rust array.
 /// # }
 /// ```
@@ -75,7 +75,7 @@ where
 /// use numpy::{PyArray, ToPyArray};
 /// let gil = pyo3::Python::acquire_gil();
 /// let py_array = vec![1, 2, 3].to_pyarray(gil.python());
-/// assert_eq!(py_array.as_slice().unwrap(), &[1, 2, 3]);
+/// assert_eq!(py_array.as_slice(), &[1, 2, 3]);
 /// # }
 /// ```
 pub trait ToPyArray {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!     let py = gil.python();
 //!     let py_array = array![[1i64, 2], [3, 4]].to_pyarray(py);
 //!     assert_eq!(
-//!         py_array.as_array().unwrap(),
+//!         py_array.as_array(),
 //!         array![[1i64, 2], [3, 4]]
 //!     );
 //! }

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -24,13 +24,11 @@ const CAPSULE_NAME: &str = "_ARRAY_API";
 /// use numpy::{PyArray, npyffi::types::NPY_SORTKIND, PY_ARRAY_API};
 /// use pyo3::Python;
 /// let gil = Python::acquire_gil();
-/// let array = PyArray::arange(gil.python(), 2, 5, 1);
-/// array.as_slice_mut().unwrap().swap(0, 1);
-/// assert_eq!(array.as_slice().unwrap(), &[3, 2, 4]);
+/// let array = PyArray::from_slice(gil.python(), &[3, 2, 4]);
 /// unsafe {
 ///     PY_ARRAY_API.PyArray_Sort(array.as_array_ptr(), 0, NPY_SORTKIND::NPY_QUICKSORT);
 /// }
-/// assert_eq!(array.as_slice().unwrap(), &[2, 3, 4])
+/// assert_eq!(array.as_slice(), &[2, 3, 4])
 /// # }
 /// ```
 pub static PY_ARRAY_API: PyArrayAPI = PyArrayAPI {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -59,14 +59,14 @@ fn arange() {
     let arr = PyArray::<f64, _>::arange(gil.python(), 0.0, 1.0, 0.1);
     println!("ndim = {:?}", arr.ndim());
     println!("dims = {:?}", arr.dims());
-    println!("array = {:?}", arr.as_slice().unwrap());
+    println!("array = {:?}", arr.as_slice());
 }
 
 #[test]
 fn as_array() {
     let gil = pyo3::Python::acquire_gil();
     let arr = PyArray::<f64, _>::zeros(gil.python(), [3, 2, 4], false);
-    let a = arr.as_array().unwrap();
+    let a = arr.as_array();
     assert_eq!(arr.shape(), a.shape());
     assert_eq!(
         arr.strides().iter().map(|x| x / 8).collect::<Vec<_>>(),
@@ -81,7 +81,7 @@ fn to_pyarray_vec() {
     let a = vec![1, 2, 3];
     let arr = a.to_pyarray(gil.python());
     println!("arr.shape = {:?}", arr.shape());
-    println!("arr = {:?}", arr.as_slice().unwrap());
+    println!("arr = {:?}", arr.as_slice());
     assert_eq!(arr.shape(), [3]);
 }
 
@@ -105,17 +105,14 @@ fn to_pyarray_array() {
 fn iter_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
     let arr = PyArray::from_iter(gil.python(), (0..10).map(|x| x * x));
-    assert_eq!(
-        arr.as_slice().unwrap(),
-        &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
-    );
+    assert_eq!(arr.as_slice(), &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
 }
 
 #[test]
 fn long_iter_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
     let arr = PyArray::from_iter(gil.python(), (0u32..512).map(|x| x));
-    let slice = arr.as_slice().unwrap();
+    let slice = arr.as_slice();
     for (i, &elem) in slice.iter().enumerate() {
         assert_eq!(i as u32, elem);
     }
@@ -135,7 +132,7 @@ fn from_vec2() {
     let vec2 = vec![vec![1, 2, 3]; 2];
     let gil = pyo3::Python::acquire_gil();
     let pyarray = PyArray::from_vec2(gil.python(), &vec2).unwrap();
-    assert_eq!(pyarray.as_array().unwrap(), array![[1, 2, 3], [1, 2, 3]]);
+    assert_eq!(pyarray.as_array(), array![[1, 2, 3], [1, 2, 3]]);
     assert!(PyArray::from_vec2(gil.python(), &vec![vec![1], vec![2, 3]]).is_err());
 }
 
@@ -145,7 +142,7 @@ fn from_vec3() {
     let vec3 = vec![vec![vec![1, 2]; 2]; 2];
     let pyarray = PyArray::from_vec3(gil.python(), &vec3).unwrap();
     assert_eq!(
-        pyarray.as_array().unwrap(),
+        pyarray.as_array(),
         array![[[1, 2], [1, 2]], [[1, 2], [1, 2]]]
     );
 }
@@ -162,7 +159,7 @@ fn from_eval() {
         .unwrap()
         .extract()
         .unwrap();
-    assert_eq!(pyarray.as_slice().unwrap(), &[1, 2, 3]);
+    assert_eq!(pyarray.as_slice(), &[1, 2, 3]);
 }
 
 #[test]
@@ -188,7 +185,7 @@ macro_rules! small_array_test {
                 let array: [$t; 2] = [$t::min_value(), $t::max_value()];
                 let pyarray = array.to_pyarray(gil.python());
                 assert_eq!(
-                    pyarray.as_slice().unwrap(),
+                    pyarray.as_slice(),
                     &[$t::min_value(), $t::max_value()]
                 );
             })+
@@ -204,7 +201,7 @@ fn array_cast() {
     let vec2 = vec![vec![1.0, 2.0, 3.0]; 2];
     let arr_f64 = PyArray::from_vec2(gil.python(), &vec2).unwrap();
     let arr_i32: &PyArray2<i32> = arr_f64.cast(false).unwrap();
-    assert_eq!(arr_i32.as_array().unwrap(), array![[1, 2, 3], [1, 2, 3]]);
+    assert_eq!(arr_i32.as_array(), array![[1, 2, 3], [1, 2, 3]]);
 }
 
 #[test]
@@ -212,7 +209,7 @@ fn into_pyarray_vec() {
     let gil = pyo3::Python::acquire_gil();
     let a = vec![1, 2, 3];
     let arr = a.into_pyarray(gil.python());
-    assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
+    assert_eq!(arr.as_slice(), &[1, 2, 3])
 }
 
 #[test]


### PR DESCRIPTION
1. If we construct `PyArray` via Rust API
It's already type checked.
2. If we construct `PyArray` in Python
It's type checked when `FromPyObject::extract`.

In both cases `PyArray` is already type checked when we can apply methods to it.
So I think we don't have to do type check in `as_array` and `as_slice`, though it's left  as assertion.