### PR TITLE
Fix simple-extension example readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2.43"
 num-complex = "0.2.1"
 num-traits = "0.2.6"
 ndarray = "0.12.0"
-pyo3 = "0.5.0"
+pyo3 = "= 0.5.0"
 
 [features]
 # In default setting, python version is automatically detected

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -12,5 +12,5 @@ numpy = { path = "../.." }
 ndarray = "0.12"
 
 [dependencies.pyo3]
-version = "0.5.0-alpha.2"
+version = "= 0.5.0"
 features = ["extension-module"]

--- a/examples/simple-extension/README.md
+++ b/examples/simple-extension/README.md
@@ -21,5 +21,6 @@ import rust_ext
 
 a = np.array([0.0, 1.0])
 b = np.array([2.0, 3.0])
-rust_ext(2.0, a, b)
+rust_ext.axpy(2.0, a, b)
 ```
+which returns `array([2., 5.])`.


### PR DESCRIPTION
The python code in the `simple-extension` example readme doesn't seem to be complete.

When running it in its present form one gets an error about a module not being callable.

`rust_ext.axpy` function was probably meant to be called.