### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "numpy"
-version = "0.4.0-alpha.1"
-authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
-
+version = "0.4.0"
+authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>", "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>"]
 description = "Rust binding of NumPy C-API"
-documentation = "https://docs.rs/numpy/"
-repository = "https://github.com/termoshtt/rust-numpy"
+documentation = "https://rust-numpy.github.io/rust-numpy/numpy"
+repository = "https://github.com/rust-numpy/rust-numpy"
 keywords = ["numpy", "python", "binding"]
 license-file = "LICENSE"
 
 [dependencies]
 cfg-if = "0.1.6"
-libc = "0.2.43"
+libc = "0.2.44"
 num-complex = "0.2.1"
 num-traits = "0.2.6"
-ndarray = "0.12.0"
-pyo3 = "= 0.5.0"
+ndarray = "0.12"
+pyo3 = "0.5.2"
 
 [features]
 # In default setting, python version is automatically detected

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ If you want to compile for Python2, please add a feature flag in `Cargo.toml` li
 
 ``` toml
 [dependencies.numpy]
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 features = ["python2"]
 ```
 .
 
-You can also automatically specify python version in [setup.py](examples/simple-extension/setup.py)
-, using [setuptools-rust](https://github.com/PyO3/setuptools-rust).
+You can also automatically specify python version in [setup.py](examples/simple-extension/setup.py), 
+using [setuptools-rust](https://github.com/PyO3/setuptools-rust).
 
 
 Example
@@ -56,8 +56,8 @@ Example
 name = "numpy-test"
 
 [dependencies]
-pyo3 = "^0.5.0-alpha.2"
-numpy = "0.4.0-alpha.1"
+pyo3 = "0.5.2"
+numpy = "0.4.0"
 ```
 
 ``` rust
@@ -100,11 +100,11 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-numpy = "0.4.0-alpha.1"
+numpy = "0.4.0"
 ndarray = "0.12"
 
 [dependencies.pyo3]
-version = "^0.5.0-alpha.2"
+version = "0.5.2"
 features = ["extension-module"]
 ```
 
@@ -157,11 +157,13 @@ fn rust_ext(_py: Python, m: &PyModule) -> PyResult<()> {
 Contribution
 -------------
 This project is still in pre-alpha.
-We need your feedback. Don't hesitate to open [issues](https://github.com/termoshtt/rust-numpy/issues)!
+
+We need your feedback. 
+Don't hesitate to open [issues](https://github.com/termoshtt/rust-numpy/issues)!
 
 Version
 --------
-- v0.4.0(coming soon)
+- v0.4.0
   - Duplicate `PyArrayModule` and import Numpy API automatically
   - Fix memory leak of `IntoPyArray` and add `ToPyArray` crate
   - PyArray has dimension as type parameter. Now it looks like `PyArray<T, D>`

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -12,5 +12,5 @@ numpy = { path = "../.." }
 ndarray = "0.12"
 
 [dependencies.pyo3]
-version = "= 0.5.0"
+version = "0.5.2"
 features = ["extension-module"]


### PR DESCRIPTION
PyO3 0.5.2 has a very important bug fix so it's time to Release not-alpha version.