### PR TITLE
Lint examples/simple-extension and try to simplify setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,11 @@ before_install:
   - source ./ci/travis/setup.sh
 
 install:
-  - pip install setuptools-rust pytest pytest-benchmark tox numpy
+  - pip install setuptools-rust pytest pytest-benchmark \
+             tox numpy flake8
 
 script:
+  - flake8 examples/
   - ./ci/travis/test.sh
 
 deploy:

--- a/examples/simple-extension/rust_ext/__init__.py
+++ b/examples/simple-extension/rust_ext/__init__.py
@@ -1,1 +1,1 @@
-from .rust_ext import *
+from .rust_ext import *  # noqa

--- a/examples/simple-extension/setup.py
+++ b/examples/simple-extension/setup.py
@@ -1,12 +1,12 @@
-import os
-import subprocess
 import sys
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 from setuptools_rust import RustExtension
 
+
 class PyTest(TestCommand):
     user_options = []
+
     def run(self):
         self.run_command("test_rust")
         import subprocess
@@ -21,12 +21,14 @@ def get_cfg_flags():
     else:
         return ['--cfg=Py_3']
 
+
 def get_features():
     version = sys.version_info[0:2]
     if version[0] == 2:
         return ['numpy/python2']
     else:
         return ['numpy/python3']
+
 
 setup_requires = ['setuptools-rust>=0.6.0']
 install_requires = ['numpy']

--- a/examples/simple-extension/setup.py
+++ b/examples/simple-extension/setup.py
@@ -1,34 +1,9 @@
 import sys
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 from setuptools_rust import RustExtension
 
 
-class PyTest(TestCommand):
-    user_options = []
-
-    def run(self):
-        self.run_command("test_rust")
-        import subprocess
-        errno = subprocess.call(['pytest', 'tests'])
-        raise SystemExit(errno)
-
-
-def get_cfg_flags():
-    version = sys.version_info[0:2]
-    if version[0] == 2:
-        return ['--cfg=Py_2']
-    else:
-        return ['--cfg=Py_3']
-
-
-def get_features():
-    version = sys.version_info[0:2]
-    if version[0] == 2:
-        return ['numpy/python2']
-    else:
-        return ['numpy/python3']
-
+PYTHON_MAJOR_VERSION = sys.version_info[0]
 
 setup_requires = ['setuptools-rust>=0.6.0']
 install_requires = ['numpy']
@@ -41,13 +16,12 @@ setup(
     rust_extensions=[RustExtension(
         'rust_ext.rust_ext',
         './Cargo.toml',
-        rustc_flags=get_cfg_flags(),
-        features=get_features(),
+        rustc_flags=['--cfg=Py_{}'.format(PYTHON_MAJOR_VERSION)],
+        features=['numpy/python{}'.format(PYTHON_MAJOR_VERSION)],
     )],
     install_requires=install_requires,
     setup_requires=setup_requires,
     test_requires=test_requires,
     packages=find_packages(),
     zip_safe=False,
-    cmdclass=dict(test=PyTest)
 )

--- a/examples/simple-extension/tests/test_ext.py
+++ b/examples/simple-extension/tests/test_ext.py
@@ -1,6 +1,6 @@
 import numpy as np
 from rust_ext import axpy, mult
-import pytest
+
 
 def test_axpy():
     x = np.array([1.0, 2.0, 3.0])
@@ -12,8 +12,8 @@ def test_axpy():
     z = axpy(3.0, x, y)
     np.testing.assert_array_almost_equal(z, np.array([6.0, 9.0, 12.0, 15.0]))
 
+
 def test_mult():
     x = np.array([1.0, 2.0, 3.0])
     mult(3.0, x)
     np.testing.assert_array_almost_equal(x, np.array([3.0, 6.0, 9.0]))
-

--- a/examples/simple-extension/tox.ini
+++ b/examples/simple-extension/tox.ini
@@ -10,5 +10,4 @@ skip_missing_interpreters = true
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
 usedevelop = True
-commands = pip install -e .
-           pytest
+commands = pytest


### PR DESCRIPTION
This lints examples/simple-extension with flake8 for PEP8 code style. Added a check in Travis CI.

Also tried to simplify a bit the `setup.py`. The main point is that to run test, it should be sufficient to run,
```
pytest tests/
```
The use of `setup.py test` is a bit outdated  (see e.g. [[1](https://blog.ionelmc.ro/2014/05/25/python-packaging/#running-the-tests)], [[2](https://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command)]) and I think it's simpler to just run `pytest test` directly (or use tox as it's done here).

Marking as WIP, I'm not fully sure if something else would need fixing in `tox.ini`..