### PR TITLE
Allow *mut ffi::PyObject as an element of PyArray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 
 script:
   - flake8 examples/
-  - travis_wait ./ci/travis/test.sh
+  - ./ci/travis/test.sh
 
 deploy:
   - provider: script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,6 @@ build_script:
   - cargo build --verbose --features %FEATURES%
 
 test_script:
-  - cargo test --verbose --features %FEATURES%
+  - cargo test --verbose --features %FEATURES% -- --test-threads=1
   - rustdoc --test README.md -L native="%PYTHON%\\libs" -L target/debug/deps/
   - cd examples/simple-extension && python setup.py install && python setup.py test

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 cargo build --verbose --features $FEATURES
-cargo test --verbose --features $FEATURES
+cargo test --verbose --features $FEATURES -- --test-threads=1
 rustdoc -L target/debug/deps/ --test README.md
 
 for example in examples/*; do

--- a/src/array.rs
+++ b/src/array.rs
@@ -482,28 +482,6 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
         unsafe { ArrayViewMut::from_shape_ptr(self.ndarray_shape(), self.data()) }
     }
 
-    /// Get a copy of `PyArray` as
-    /// [`ndarray::Array`](https://docs.rs/ndarray/0.12/ndarray/type.Array.html).
-    ///
-    /// # Example
-    /// ```
-    /// # #[macro_use] extern crate ndarray; extern crate pyo3; extern crate numpy; fn main() {
-    /// use numpy::PyArray;
-    /// let gil = pyo3::Python::acquire_gil();
-    /// let py_array = PyArray::arange(gil.python(), 0, 4, 1).reshape([2, 2]).unwrap();
-    /// assert_eq!(
-    ///     py_array.to_owned_array(),
-    ///     array![[0, 1], [2, 3]]
-    /// )
-    /// # }
-    /// ```
-    pub fn to_owned_array(&self) -> Array<T, D> {
-        unsafe {
-            let vec = self.as_slice().to_owned();
-            Array::from_shape_vec_unchecked(self.ndarray_shape(), vec)
-        }
-    }
-
     /// Get an immutable reference of a specified element, without checking the
     /// passed index is valid.
     ///
@@ -616,6 +594,30 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
             Ok(())
         } else {
             Err(ErrorKind::to_rust(truth, dim, T::npy_data_type(), D::NDIM))
+        }
+    }
+}
+
+impl<T: TypeNum + Clone, D: Dimension> PyArray<T, D> {
+    /// Get a copy of `PyArray` as
+    /// [`ndarray::Array`](https://docs.rs/ndarray/0.12/ndarray/type.Array.html).
+    ///
+    /// # Example
+    /// ```
+    /// # #[macro_use] extern crate ndarray; extern crate pyo3; extern crate numpy; fn main() {
+    /// use numpy::PyArray;
+    /// let gil = pyo3::Python::acquire_gil();
+    /// let py_array = PyArray::arange(gil.python(), 0, 4, 1).reshape([2, 2]).unwrap();
+    /// assert_eq!(
+    ///     py_array.to_owned_array(),
+    ///     array![[0, 1], [2, 3]]
+    /// )
+    /// # }
+    /// ```
+    pub fn to_owned_array(&self) -> Array<T, D> {
+        unsafe {
+            let vec = self.as_slice().to_vec();
+            Array::from_shape_vec_unchecked(self.ndarray_shape(), vec)
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ pub use num_complex::Complex32 as c32;
 pub use num_complex::Complex64 as c64;
 
 use super::npyffi::NPY_TYPES;
-use pyo3::PyObject;
+use pyo3::ffi::PyObject;
 
 /// An enum type represents numpy data type.
 ///
@@ -103,7 +103,7 @@ impl_type_num!(f32, Float32, NPY_FLOAT);
 impl_type_num!(f64, Float64, NPY_DOUBLE);
 impl_type_num!(c32, Complex32, NPY_CFLOAT);
 impl_type_num!(c64, Complex64, NPY_CDOUBLE);
-impl_type_num!(PyObject, PyObject, NPY_OBJECT);
+impl_type_num!(*mut PyObject, PyObject, NPY_OBJECT);
 
 cfg_if! {
     if #[cfg(any(target_pointer_width = "32", windows))] {

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ pub use num_complex::Complex32 as c32;
 pub use num_complex::Complex64 as c64;
 
 use super::npyffi::NPY_TYPES;
+use pyo3::PyObject;
 
 /// An enum type represents numpy data type.
 ///
@@ -24,6 +25,7 @@ pub enum NpyDataType {
     Float64,
     Complex32,
     Complex64,
+    PyObject,
     Unsupported,
 }
 
@@ -45,6 +47,7 @@ impl NpyDataType {
             x if x == NPY_TYPES::NPY_DOUBLE as i32 => NpyDataType::Float64,
             x if x == NPY_TYPES::NPY_CFLOAT as i32 => NpyDataType::Complex32,
             x if x == NPY_TYPES::NPY_CDOUBLE as i32 => NpyDataType::Complex64,
+            x if x == NPY_TYPES::NPY_OBJECT as i32 => NpyDataType::PyObject,
             _ => NpyDataType::Unsupported,
         }
     }
@@ -68,7 +71,7 @@ impl NpyDataType {
     }
 }
 
-pub trait TypeNum: Clone {
+pub trait TypeNum {
     fn is_same_type(other: i32) -> bool;
     fn npy_data_type() -> NpyDataType;
     fn typenum_default() -> i32;
@@ -100,6 +103,7 @@ impl_type_num!(f32, Float32, NPY_FLOAT);
 impl_type_num!(f64, Float64, NPY_DOUBLE);
 impl_type_num!(c32, Complex32, NPY_CFLOAT);
 impl_type_num!(c64, Complex64, NPY_CDOUBLE);
+impl_type_num!(PyObject, PyObject, NPY_OBJECT);
 
 cfg_if! {
     if #[cfg(any(target_pointer_width = "32", windows))] {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -290,11 +290,11 @@ macro_rules! py_assert {
 }
 
 #[test]
-fn into_pyarray_obj_vec() {
+fn into_obj_vec_to_pyarray() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();
-    let dict = PyDict::new(gil.python());
-    let string = pyo3::types::PyString::new(gil.python(), "Hello python :)");
+    let dict = PyDict::new(py);
+    let string = pyo3::types::PyString::new(py, "Hello python :)");
     let a = vec![dict.to_object(py), string.to_object(py)];
     let arr = a.into_pyarray(py);
     py_assert!(py, arr, "arr[0] == {}");

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -4,7 +4,7 @@ extern crate pyo3;
 
 use ndarray::*;
 use numpy::*;
-use pyo3::{prelude::*, types::PyDict, types::PyList};
+use pyo3::{prelude::*, types::PyDict, types::PyList, ToPyPointer};
 
 #[test]
 fn new_c_order() {
@@ -295,7 +295,7 @@ fn into_obj_vec_to_pyarray() {
     let py = gil.python();
     let dict = PyDict::new(py);
     let string = pyo3::types::PyString::new(py, "Hello python :)");
-    let a = vec![dict.to_object(py), string.to_object(py)];
+    let a = vec![dict.as_ptr(), string.as_ptr()];
     let arr = a.into_pyarray(py);
     py_assert!(py, arr, "arr[0] == {}");
     py_assert!(py, arr, "arr[1] == 'Hello python :)'");


### PR DESCRIPTION
Pasted the test code as example
```rust
    let py = gil.python();
    let dict = PyDict::new(py);
    let string = pyo3::types::PyString::new(py, "Hello python :)");
    let a = vec![dict.as_ptr(), string.as_ptr()];
    let arr = a.into_pyarray(py);
    py_assert!(py, arr, "arr[0] == {}");
    py_assert!(py, arr, "arr[1] == 'Hello python :)'");
```

I think it's helpful when we want to avoid `Vec -> list` overhead.