### PR TITLE
fix Uint64 type for x86_64 architectures

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -115,6 +115,6 @@ cfg_if! {
         impl_type_num!(i32, Int32, NPY_INT);
         impl_type_num!(u32, Uint32, NPY_UINT);
         impl_type_num!(i64, Int64, NPY_LONG, NPY_LONGLONG);
-        impl_type_num!(u64, Uint64, NPY_LONG, NPY_ULONGLONG);
+        impl_type_num!(u64, Uint64, NPY_ULONG, NPY_ULONGLONG);
     }
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -182,6 +182,25 @@ fn from_eval_to_dyn() {
 }
 
 #[test]
+fn from_eval_to_dyn_u64() {
+    let gil = pyo3::Python::acquire_gil();
+    let np = get_array_module(gil.python()).unwrap();
+    let dict = PyDict::new(gil.python());
+    dict.set_item("np", np).unwrap();
+    let pyarray: &PyArrayDyn<u64> = gil
+        .python()
+        .eval(
+            "np.array([[1, 2], [3, 4]], dtype='uint64')",
+            Some(&dict),
+            None,
+        )
+        .unwrap()
+        .extract()
+        .unwrap();
+    assert_eq!(pyarray.as_slice(), &[1, 2, 3, 4]);
+}
+
+#[test]
 fn from_eval_fail_by_dtype() {
     let gil = pyo3::Python::acquire_gil();
     let np = get_array_module(gil.python()).unwrap();


### PR DESCRIPTION
Passing a uint64 numpy array in an x86_64 arch raised the following
exception:

Fix the following error:
E       TypeError: Extraction failed:
E        from=(dim=1, dtype=Uint64), to=(dim=_, dtype=Uint64)
E        context: [FromPyObject::extract] typecheck failed

Now it works well