### PR TITLE
Support converting Array1<usize>

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -106,6 +106,17 @@ impl_type_num!(c64, Complex64, NPY_CDOUBLE);
 impl_type_num!(*mut PyObject, PyObject, NPY_OBJECT);
 
 cfg_if! {
+    if #[cfg(all(target_pointer_width = "64", windows))] {
+            impl_type_num!(usize, Uint64, NPY_ULONGLONG);
+    } else if #[cfg(all(target_pointer_width = "64", not (windows)))] {
+            impl_type_num!(usize, Uint64, NPY_ULONG, NPY_ULONGLONG);
+    } else if #[cfg(all(target_pointer_width = "32", windows))] {
+            impl_type_num!(usize, Uint32, NPY_UINT, NPY_ULONG);
+    } else if #[cfg(all(target_pointer_width = "32",  not (windows)))] {
+            impl_type_num!(usize, Uint32, NPY_UINT);
+    }
+}
+cfg_if! {
     if #[cfg(any(target_pointer_width = "32", windows))] {
         impl_type_num!(i32, Int32, NPY_INT, NPY_LONG);
         impl_type_num!(u32, Uint32, NPY_UINT, NPY_ULONG);

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,11 +108,11 @@ impl_type_num!(*mut PyObject, PyObject, NPY_OBJECT);
 cfg_if! {
     if #[cfg(all(target_pointer_width = "64", windows))] {
             impl_type_num!(usize, Uint64, NPY_ULONGLONG);
-    } else if #[cfg(all(target_pointer_width = "64", not (windows)))] {
+    } else if #[cfg(all(target_pointer_width = "64", not(windows)))] {
             impl_type_num!(usize, Uint64, NPY_ULONG, NPY_ULONGLONG);
     } else if #[cfg(all(target_pointer_width = "32", windows))] {
             impl_type_num!(usize, Uint32, NPY_UINT, NPY_ULONG);
-    } else if #[cfg(all(target_pointer_width = "32",  not (windows)))] {
+    } else if #[cfg(all(target_pointer_width = "32", not(windows)))] {
             impl_type_num!(usize, Uint32, NPY_UINT);
     }
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -249,7 +249,27 @@ macro_rules! small_array_test {
     };
 }
 
-small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64);
+small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64 usize);
+
+
+#[test]
+fn array_usize_dtype() {
+    let gil = pyo3::Python::acquire_gil();
+    let py = gil.python();
+    let locals = PyDict::new(py);
+
+    let a: Vec<usize> = vec![1, 2, 3];
+    let x = a.into_pyarray(py);
+    let x_repr = format!("{:?}", x);
+    
+    let x_repr_expected = if cfg!(target_pointer_width = "64") {
+        "array([1, 2, 3], dtype=uint64)"
+    } else {
+        "array([1, 2, 3], dtype=uint32)"
+    };
+
+    assert_eq!(x_repr, x_repr_expected);
+}
 
 #[test]
 fn array_cast() {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -251,7 +251,6 @@ macro_rules! small_array_test {
 
 small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64 usize);
 
-
 #[test]
 fn array_usize_dtype() {
     let gil = pyo3::Python::acquire_gil();
@@ -261,13 +260,12 @@ fn array_usize_dtype() {
     let a: Vec<usize> = vec![1, 2, 3];
     let x = a.into_pyarray(py);
     let x_repr = format!("{:?}", x);
-    
+
     let x_repr_expected = if cfg!(target_pointer_width = "64") {
         "array([1, 2, 3], dtype=uint64)"
     } else {
         "array([1, 2, 3], dtype=uint32)"
     };
-
     assert_eq!(x_repr, x_repr_expected);
 }
 


### PR DESCRIPTION
On master, trying to convert e.g. an `Array1<usize>` to Python fails due to the conversion not being implemented for `usize` dtype.

I tried to add it following the suggestion in https://github.com/rust-ndarray/ndarray/issues/493#issuecomment-424043912

If I understand correctly, usize should map to either `np.uint32` or `np.uint64` depending on the architecture.