### PR TITLE
MAINT Fix linalg example to use PyO3 0.7

### DIFF
--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -14,5 +14,5 @@ ndarray = "0.12"
 ndarray-linalg = { version = "0.10", features = ["openblas"] }
 
 [dependencies.pyo3]
-version = "0.6"
+version = "0.7"
 features = ["extension-module"]

--- a/examples/linalg/setup.py
+++ b/examples/linalg/setup.py
@@ -1,4 +1,3 @@
-import sys
 from setuptools import find_packages, setup
 from setuptools_rust import RustExtension
 

--- a/examples/linalg/setup.py
+++ b/examples/linalg/setup.py
@@ -3,8 +3,6 @@ from setuptools import find_packages, setup
 from setuptools_rust import RustExtension
 
 
-PYTHON_MAJOR_VERSION = sys.version_info[0]
-
 setup_requires = ['setuptools-rust>=0.6.0']
 install_requires = ['numpy']
 test_requires = install_requires + ['pytest']

--- a/examples/simple-extension/setup.py
+++ b/examples/simple-extension/setup.py
@@ -1,4 +1,3 @@
-import sys
 from setuptools import find_packages, setup
 from setuptools_rust import RustExtension
 

--- a/examples/simple-extension/setup.py
+++ b/examples/simple-extension/setup.py
@@ -3,8 +3,6 @@ from setuptools import find_packages, setup
 from setuptools_rust import RustExtension
 
 
-PYTHON_MAJOR_VERSION = sys.version_info[0]
-
 setup_requires = ['setuptools-rust>=0.6.0']
 install_requires = ['numpy']
 test_requires = install_requires + ['pytest']


### PR DESCRIPTION
Looks like this may have been left out from https://github.com/rust-numpy/rust-numpy/pull/96

Without this change I wasn't able to build the linalg example.