### PR TITLE
Update pyo3 to 0.8 and bump version to 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+- v0.7.0
+  - Update PyO3 to 0.8
+
 - v0.6.0
   - Update PyO3 to 0.7
   - Drop Python2 support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numpy"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>", "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>"]
 description = "Rust binding of NumPy C-API"
 documentation = "https://rust-numpy.github.io/rust-numpy/numpy"
@@ -15,7 +15,7 @@ libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
 ndarray = "0.12"
-pyo3 = {git = "https://github.com/PyO3/pyo3"}
+pyo3 = "0.8"
 
 [features]
 # In default setting, python version is automatically detected

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
 ndarray = "0.12"
-pyo3 = "0.7"
+pyo3 = {git = "https://github.com/PyO3/pyo3"}
 
 [features]
 # In default setting, python version is automatically detected

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cfg-if = "0.1"
 libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
-ndarray = "0.12"
+ndarray = ">=0.12"
 pyo3 = "0.8"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ using [setuptools-rust](https://github.com/PyO3/setuptools-rust).
 name = "numpy-test"
 
 [dependencies]
-pyo3 = "0.7"
-numpy = "0.6.0"
+pyo3 = "0.8"
+numpy = "0.7.0"
 ```
 
 ```rust
@@ -98,11 +98,11 @@ name = "rust_ext"
 crate-type = ["cdylib"]
 
 [dependencies]
-numpy = "0.6.0"
+numpy = "0.7.0"
 ndarray = "0.12"
 
 [dependencies.pyo3]
-version = "0.7"
+version = "0.8"
 features = ["extension-module"]
 ```
 

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -14,5 +14,5 @@ ndarray = "0.12"
 ndarray-linalg = { version = "0.10", features = ["openblas"] }
 
 [dependencies.pyo3]
-version = "0.7"
+version = "0.8"
 features = ["extension-module"]

--- a/examples/linalg/setup.py
+++ b/examples/linalg/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from setuptools_rust import RustExtension
 
 
-setup_requires = ['setuptools-rust>=0.6.0']
+setup_requires = ['setuptools-rust>=0.10.2']
 install_requires = ['numpy']
 test_requires = install_requires + ['pytest']
 

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -13,5 +13,5 @@ numpy = { path = "../.." }
 ndarray = "0.12"
 
 [dependencies.pyo3]
-version = "0.7"
+version = "0.8"
 features = ["extension-module"]

--- a/examples/simple-extension/setup.py
+++ b/examples/simple-extension/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from setuptools_rust import RustExtension
 
 
-setup_requires = ['setuptools-rust>=0.6.0']
+setup_requires = ['setuptools-rust>=0.10.2']
 install_requires = ['numpy']
 test_requires = install_requires + ['pytest']
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -102,6 +102,7 @@ pub fn get_array_module(py: Python<'_>) -> PyResult<&PyModule> {
 pyobject_native_type_convert!(
     PyArray<T, D>,
     *npyffi::PY_ARRAY_API.get_type_object(npyffi::ArrayType::PyArray_Type),
+    Some("numpy"),
     npyffi::PyArray_Check,
     T, D
 );
@@ -133,8 +134,8 @@ impl<'a, T: TypeNum, D: Dimension> FromPyObject<'a> for &'a PyArray<T, D> {
     }
 }
 
-impl<T, D> IntoPyObject for PyArray<T, D> {
-    fn into_object(self, _py: Python<'_>) -> PyObject {
+impl<T, D> IntoPy<PyObject> for PyArray<T, D> {
+    fn into_py(self, _py: Python<'_>) -> PyObject {
         self.0
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -414,7 +414,7 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
     /// # #[macro_use] extern crate ndarray; fn main() {
     /// use numpy::PyArray2;
     /// let gil = pyo3::Python::acquire_gil();
-    /// let pyarray = PyArray2::zeros(gil.python(), [2, 2], false);
+    /// let pyarray: &PyArray2<usize> = PyArray2::zeros(gil.python(), [2, 2], false);
     /// assert_eq!(pyarray.as_array(), array![[0, 0], [0, 0]]);
     /// # }
     /// ```

--- a/src/slice_box.rs
+++ b/src/slice_box.rs
@@ -29,6 +29,7 @@ impl<T> type_object::PyTypeInfo for SliceBox<T> {
     type Type = ();
     type BaseType = PyAny;
     const NAME: &'static str = "SliceBox";
+    const MODULE: Option<&'static str> = Some("_rust_numpy");
     const DESCRIPTION: &'static str = "Memory store for PyArray using rust's Box<[T]>.";
     const FLAGS: usize = 0;
     const SIZE: usize = std::mem::size_of::<Self>();


### PR DESCRIPTION
### TODO
- [x] Modify `Cargo.toml` when 0.8 is released
- [x] Check if the module name is appropriate again