### PR TITLE
Disable Vec<*mut ffi::PyObject> <-> numpy.ndarray conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = "0.7.0"
-ndarray = "0.12"
+ndarray = "0.13"
 
 [dependencies.pyo3]
 version = "0.8"

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-ndarray = "0.12"
+ndarray = ">= 0.12"
 ndarray-linalg = { version = "0.10", features = ["openblas"] }
 
 [dependencies.pyo3]

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = { path = "../.." }
-ndarray = "0.12"
+ndarray = ">= 0.12"
 
 [dependencies.pyo3]
 version = "0.8"

--- a/src/array.rs
+++ b/src/array.rs
@@ -379,7 +379,7 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
     pub(crate) unsafe fn from_boxed_slice<'py, ID>(
         py: Python<'py>,
         dims: ID,
-        strides: *mut npy_intp,
+        strides: *const npy_intp,
         slice: Box<[T]>,
     ) -> &'py Self
     where
@@ -392,11 +392,11 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
             dims.ndim_cint(),
             dims.as_dims_ptr(),
             T::typenum_default(),
-            strides,                // strides
-            slice.data(),           // data
-            0,                      // itemsize
-            0,                      // flag
-            ::std::ptr::null_mut(), //obj
+            strides as *mut _,          // strides
+            slice.data(),               // data
+            mem::size_of::<T>() as i32, // itemsize
+            0,                          // flag
+            ::std::ptr::null_mut(),     //obj
         );
         PY_ARRAY_API.PyArray_SetBaseObject(ptr as *mut npyffi::PyArrayObject, slice.as_ptr());
         Self::from_owned_ptr(py, ptr)

--- a/src/array.rs
+++ b/src/array.rs
@@ -50,7 +50,7 @@ use crate::types::{NpyDataType, TypeNum};
 /// All data types you can use implements [TypeNum](../types/trait.TypeNum.html).
 ///
 /// Dimensions are represented by ndarray's
-/// [Dimension](https://docs.rs/ndarray/0.12/ndarray/trait.Dimension.html) trait.
+/// [Dimension](https://docs.rs/ndarray/latest/ndarray/trait.Dimension.html) trait.
 ///
 /// Typically, you can use `Ix1, Ix2, ..` for fixed size arrays, and use `IxDyn` for dynamic
 /// dimensioned arrays. They're re-exported from `ndarray` crate.
@@ -59,7 +59,7 @@ use crate::types::{NpyDataType, TypeNum};
 /// or [`PyArrayDyn`](./type.PyArrayDyn.html).
 ///
 /// To specify concrete dimension like `3×4×5`, you can use types which implements ndarray's
-/// [`IntoDimension`](https://docs.rs/ndarray/0.12/ndarray/dimension/conversion/trait.IntoDimension.html)
+/// [`IntoDimension`](https://docs.rs/ndarray/latest/ndarray/dimension/conversion/trait.IntoDimension.html)
 /// trait. Typically, you can use array(e.g. `[3, 4, 5]`) or tuple(e.g. `(3, 4, 5)`) as a dimension.
 ///
 /// # Example
@@ -497,7 +497,7 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
     }
 
     /// Construct PyArray from
-    /// [`ndarray::Array`](https://docs.rs/ndarray/0.12/ndarray/type.Array.html).
+    /// [`ndarray::Array`](https://docs.rs/ndarray/latest/ndarray/type.Array.html).
     ///
     /// This method uses internal [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
     /// of `ndarray::Array` as numpy array.
@@ -516,7 +516,7 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
     }
 
     /// Get the immutable view of the internal data of `PyArray`, as
-    /// [`ndarray::ArrayView`](https://docs.rs/ndarray/0.12/ndarray/type.ArrayView.html).
+    /// [`ndarray::ArrayView`](https://docs.rs/ndarray/latest/ndarray/type.ArrayView.html).
     ///
     /// # Example
     /// ```
@@ -659,7 +659,7 @@ impl<T: TypeNum, D: Dimension> PyArray<T, D> {
 
 impl<T: TypeNum + Clone, D: Dimension> PyArray<T, D> {
     /// Get a copy of `PyArray` as
-    /// [`ndarray::Array`](https://docs.rs/ndarray/0.12/ndarray/type.Array.html).
+    /// [`ndarray::Array`](https://docs.rs/ndarray/latest/ndarray/type.Array.html).
     ///
     /// # Example
     /// ```

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -150,7 +150,7 @@ impl<D: Dimension> ToNpyDims for D {
 /// Types that can be used to index an array.
 ///
 /// See
-/// [IntoDimension](https://docs.rs/ndarray/0.12/ndarray/dimension/conversion/trait.IntoDimension.html)
+/// [IntoDimension](https://docs.rs/ndarray/latest/ndarray/dimension/conversion/trait.IntoDimension.html)
 /// for what types you can use as `NpyIndex`.
 ///
 /// But basically, you can use

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -1,13 +1,7 @@
 //! Low-Level bindings for NumPy C API.
 //!
 //! https://docs.scipy.org/doc/numpy/reference/c-api.html
-//!
-//! Most of functions in this submodule are unsafe.
-//! If you use functions in this submodule, you need to understand
-//! basic usage of Python C API, especially for the reference counting.
-//!
-//! - http://docs.python.jp/3/c-api/
-//! - http://dgrunwald.github.io/rust-pyo3/doc/pyo3/
+#![allow(non_camel_case_types)]
 
 use pyo3::ffi;
 use std::ffi::CString;

--- a/src/npyffi/mod.rs
+++ b/src/npyffi/mod.rs
@@ -41,7 +41,7 @@ macro_rules! impl_api {
         #[allow(non_snake_case)]
         pub unsafe fn $fname(&self, $($arg : $t), *) $( -> $ret )* {
             let fptr = self.0.offset($offset)
-                               as (*const extern fn ($($arg : $t), *) $( -> $ret )* );
+                               as *const extern fn ($($arg : $t), *) $( -> $ret )*;
             (*fptr)($($arg), *)
         }
     }

--- a/src/npyffi/objects.rs
+++ b/src/npyffi/objects.rs
@@ -1,7 +1,7 @@
 //! Low-Lebel binding for NumPy C API C-objects
 //!
 //! https://docs.scipy.org/doc/numpy/reference/c-api.types-and-structures.html
-#![allow(non_camel_case_types, non_snake_case)]
+#![allow(non_camel_case_types)]
 
 use libc::FILE;
 use pyo3::ffi::*;

--- a/src/npyffi/types.rs
+++ b/src/npyffi/types.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types)]
-
 use pyo3::ffi::{Py_hash_t, Py_intptr_t, Py_uintptr_t};
 use std::os::raw::*;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,6 @@ pub use num_complex::Complex32 as c32;
 pub use num_complex::Complex64 as c64;
 
 use super::npyffi::NPY_TYPES;
-use pyo3::ffi::PyObject;
 
 /// An enum type represents numpy data type.
 ///
@@ -25,7 +24,6 @@ pub enum NpyDataType {
     Float64,
     Complex32,
     Complex64,
-    PyObject,
     Unsupported,
 }
 
@@ -47,7 +45,6 @@ impl NpyDataType {
             x if x == NPY_TYPES::NPY_DOUBLE as i32 => NpyDataType::Float64,
             x if x == NPY_TYPES::NPY_CFLOAT as i32 => NpyDataType::Complex32,
             x if x == NPY_TYPES::NPY_CDOUBLE as i32 => NpyDataType::Complex64,
-            x if x == NPY_TYPES::NPY_OBJECT as i32 => NpyDataType::PyObject,
             _ => NpyDataType::Unsupported,
         }
     }
@@ -103,7 +100,6 @@ impl_type_num!(f32, Float32, NPY_FLOAT);
 impl_type_num!(f64, Float64, NPY_DOUBLE);
 impl_type_num!(c32, Complex32, NPY_CFLOAT);
 impl_type_num!(c64, Complex64, NPY_CDOUBLE);
-impl_type_num!(*mut PyObject, PyObject, NPY_OBJECT);
 
 cfg_if! {
     if #[cfg(all(target_pointer_width = "64", windows))] {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -4,7 +4,6 @@ use pyo3::{
     prelude::*,
     types::PyList,
     types::{IntoPyDict, PyDict},
-    AsPyPointer,
 };
 
 fn get_np_locals(py: Python<'_>) -> &'_ PyDict {
@@ -100,53 +99,6 @@ fn as_slice() {
     assert_eq!(arr.as_slice().unwrap().len(), 3 * 2 * 4);
     let not_contiguous = not_contiguous_array(py);
     assert!(not_contiguous.as_slice().is_err())
-}
-
-#[test]
-fn to_pyarray_vec() {
-    let gil = pyo3::Python::acquire_gil();
-
-    let a = vec![1, 2, 3];
-    let arr = a.to_pyarray(gil.python());
-    println!("arr.shape = {:?}", arr.shape());
-    assert_eq!(arr.shape(), [3]);
-    assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
-}
-
-#[test]
-fn to_pyarray_array() {
-    let gil = pyo3::Python::acquire_gil();
-
-    let a = Array3::<f64>::zeros((3, 4, 2));
-    let shape = a.shape().iter().cloned().collect::<Vec<_>>();
-    let strides = a.strides().iter().map(|d| d * 8).collect::<Vec<_>>();
-    println!("a.shape   = {:?}", a.shape());
-    println!("a.strides = {:?}", a.strides());
-    let pa = a.to_pyarray(gil.python());
-    println!("pa.shape   = {:?}", pa.shape());
-    println!("pa.strides = {:?}", pa.strides());
-    assert_eq!(pa.shape(), shape.as_slice());
-    assert_eq!(pa.strides(), strides.as_slice());
-}
-
-#[test]
-fn iter_to_pyarray() {
-    let gil = pyo3::Python::acquire_gil();
-    let arr = PyArray::from_iter(gil.python(), (0..10).map(|x| x * x));
-    assert_eq!(
-        arr.as_slice().unwrap(),
-        &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
-    );
-}
-
-#[test]
-fn long_iter_to_pyarray() {
-    let gil = pyo3::Python::acquire_gil();
-    let arr = PyArray::from_iter(gil.python(), (0u32..512).map(|x| x));
-    let slice = arr.as_slice().unwrap();
-    for (i, &elem) in slice.iter().enumerate() {
-        assert_eq!(i as u32, elem);
-    }
 }
 
 #[test]
@@ -253,42 +205,6 @@ fn from_eval_fail_by_dim() {
         .print_and_set_sys_last_vars(gil.python());
 }
 
-macro_rules! small_array_test {
-    ($($t: ident)+) => {
-        #[test]
-        fn from_small_array() {
-            let gil = pyo3::Python::acquire_gil();
-            $({
-                let array: [$t; 2] = [$t::min_value(), $t::max_value()];
-                let pyarray = array.to_pyarray(gil.python());
-                assert_eq!(
-                    pyarray.as_slice().unwrap(),
-                    &[$t::min_value(), $t::max_value()]
-                );
-            })+
-        }
-    };
-}
-
-small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64 usize);
-
-#[test]
-fn array_usize_dtype() {
-    let gil = pyo3::Python::acquire_gil();
-    let py = gil.python();
-
-    let a: Vec<usize> = vec![1, 2, 3];
-    let x = a.into_pyarray(py);
-    let x_repr = format!("{:?}", x);
-
-    let x_repr_expected = if cfg!(target_pointer_width = "64") {
-        "array([1, 2, 3], dtype=uint64)"
-    } else {
-        "array([1, 2, 3], dtype=uint32)"
-    };
-    assert_eq!(x_repr, x_repr_expected);
-}
-
 #[test]
 fn array_cast() {
     let gil = pyo3::Python::acquire_gil();
@@ -296,58 +212,4 @@ fn array_cast() {
     let arr_f64 = PyArray::from_vec2(gil.python(), &vec2).unwrap();
     let arr_i32: &PyArray2<i32> = arr_f64.cast(false).unwrap();
     assert_eq!(arr_i32.as_array(), array![[1, 2, 3], [1, 2, 3]]);
-}
-
-#[test]
-fn into_pyarray_vec() {
-    let gil = pyo3::Python::acquire_gil();
-    let a = vec![1, 2, 3];
-    let arr = a.into_pyarray(gil.python());
-    assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
-}
-
-#[test]
-fn into_pyarray_array() {
-    let gil = pyo3::Python::acquire_gil();
-    let arr = Array3::<f64>::zeros((3, 4, 2));
-    let shape = arr.shape().iter().cloned().collect::<Vec<_>>();
-    let strides = arr.strides().iter().map(|d| d * 8).collect::<Vec<_>>();
-    let py_arr = arr.into_pyarray(gil.python());
-    assert_eq!(py_arr.shape(), shape.as_slice());
-    assert_eq!(py_arr.strides(), strides.as_slice());
-}
-
-#[test]
-fn into_pyarray_cant_resize() {
-    let gil = pyo3::Python::acquire_gil();
-    let a = vec![1, 2, 3];
-    let arr = a.into_pyarray(gil.python());
-    assert!(arr.resize(100).is_err())
-}
-
-// TODO: Replace it by pyo3::py_run when https://github.com/PyO3/pyo3/pull/512 is released.
-macro_rules! py_run {
-    ($py:expr, $val:expr, $code:expr) => {{
-        let d = pyo3::types::PyDict::new($py);
-        d.set_item(stringify!($val), &$val).unwrap();
-        $py.run($code, None, Some(d))
-            .map_err(|e| {
-                e.print($py);
-                $py.run("import sys; sys.stderr.flush()", None, None)
-                    .unwrap();
-            })
-            .expect($code)
-    }};
-}
-
-#[test]
-fn into_obj_vec_to_pyarray() {
-    let gil = pyo3::Python::acquire_gil();
-    let py = gil.python();
-    let dict = PyDict::new(py);
-    let string = pyo3::types::PyString::new(py, "Hello python :)");
-    let a = vec![dict.as_ptr(), string.as_ptr()];
-    let arr = a.into_pyarray(py);
-    py_run!(py, arr, "assert arr[0] == {}");
-    py_run!(py, arr, "assert arr[1] == 'Hello python :)'");
 }

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -68,6 +68,7 @@ macro_rules! small_array_test {
 small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64 usize);
 
 #[test]
+#[ignore]
 fn usize_dtype() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -1,0 +1,112 @@
+use ndarray::*;
+use numpy::*;
+
+#[test]
+fn to_pyarray_vec() {
+    let gil = pyo3::Python::acquire_gil();
+
+    let a = vec![1, 2, 3];
+    let arr = a.to_pyarray(gil.python());
+    println!("arr.shape = {:?}", arr.shape());
+    assert_eq!(arr.shape(), [3]);
+    assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
+}
+
+#[test]
+fn to_pyarray_array() {
+    let gil = pyo3::Python::acquire_gil();
+
+    let a = Array3::<f64>::zeros((3, 4, 2));
+    let shape = a.shape().iter().cloned().collect::<Vec<_>>();
+    let strides = a.strides().iter().map(|d| d * 8).collect::<Vec<_>>();
+    println!("a.shape   = {:?}", a.shape());
+    println!("a.strides = {:?}", a.strides());
+    let pa = a.to_pyarray(gil.python());
+    println!("pa.shape   = {:?}", pa.shape());
+    println!("pa.strides = {:?}", pa.strides());
+    assert_eq!(pa.shape(), shape.as_slice());
+    assert_eq!(pa.strides(), strides.as_slice());
+}
+
+#[test]
+fn iter_to_pyarray() {
+    let gil = pyo3::Python::acquire_gil();
+    let arr = PyArray::from_iter(gil.python(), (0..10).map(|x| x * x));
+    assert_eq!(
+        arr.as_slice().unwrap(),
+        &[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+    );
+}
+
+#[test]
+fn long_iter_to_pyarray() {
+    let gil = pyo3::Python::acquire_gil();
+    let arr = PyArray::from_iter(gil.python(), (0u32..512).map(|x| x));
+    let slice = arr.as_slice().unwrap();
+    for (i, &elem) in slice.iter().enumerate() {
+        assert_eq!(i as u32, elem);
+    }
+}
+
+macro_rules! small_array_test {
+    ($($t: ident)+) => {
+        #[test]
+        fn from_small_array() {
+            let gil = pyo3::Python::acquire_gil();
+            $({
+                let array: [$t; 2] = [$t::min_value(), $t::max_value()];
+                let pyarray = array.to_pyarray(gil.python());
+                assert_eq!(
+                    pyarray.as_slice().unwrap(),
+                    &[$t::min_value(), $t::max_value()]
+                );
+            })+
+        }
+    };
+}
+
+small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64 usize);
+
+#[test]
+fn usize_dtype() {
+    let gil = pyo3::Python::acquire_gil();
+    let py = gil.python();
+
+    let a: Vec<usize> = vec![1, 2, 3];
+    let x = a.into_pyarray(py);
+    let x_repr = format!("{:?}", x);
+
+    let x_repr_expected = if cfg!(target_pointer_width = "64") {
+        "array([1, 2, 3], dtype=uint64)"
+    } else {
+        "array([1, 2, 3], dtype=uint32)"
+    };
+    assert_eq!(x_repr, x_repr_expected);
+}
+
+#[test]
+fn into_pyarray_vec() {
+    let gil = pyo3::Python::acquire_gil();
+    let a = vec![1, 2, 3];
+    let arr = a.into_pyarray(gil.python());
+    assert_eq!(arr.as_slice().unwrap(), &[1, 2, 3])
+}
+
+#[test]
+fn into_pyarray_array() {
+    let gil = pyo3::Python::acquire_gil();
+    let arr = Array3::<f64>::zeros((3, 4, 2));
+    let shape = arr.shape().iter().cloned().collect::<Vec<_>>();
+    let strides = arr.strides().iter().map(|d| d * 8).collect::<Vec<_>>();
+    let py_arr = arr.into_pyarray(gil.python());
+    assert_eq!(py_arr.shape(), shape.as_slice());
+    assert_eq!(py_arr.strides(), strides.as_slice());
+}
+
+#[test]
+fn into_pyarray_cant_resize() {
+    let gil = pyo3::Python::acquire_gil();
+    let a = vec![1, 2, 3];
+    let arr = a.into_pyarray(gil.python());
+    assert!(arr.resize(100).is_err())
+}

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -74,14 +74,12 @@ fn usize_dtype() {
 
     let a: Vec<usize> = vec![1, 2, 3];
     let x = a.into_pyarray(py);
-    let x_repr = format!("{:?}", x);
 
-    let x_repr_expected = if cfg!(target_pointer_width = "64") {
-        "array([1, 2, 3], dtype=uint64)"
+    if cfg!(target_pointer_width = "64") {
+        pyo3::py_run!(py, x, "assert str(x.dtype) == 'uint64'")
     } else {
-        "array([1, 2, 3], dtype=uint32)"
+        pyo3::py_run!(py, x, "assert str(x.dtype) == 'uint32'")
     };
-    assert_eq!(x_repr, x_repr_expected);
 }
 
 #[test]


### PR DESCRIPTION
There are some problems with reference counting and ... now I have no idea to fix it.
Maybe `to_pyarray` can be safe but anyway `TypeNum` is not appropriate for `PyObject`.

Resolves #113.