### PR TITLE
Properly fetch errors in Python interpreter

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -813,7 +813,7 @@ impl<T: TypeNum> PyArray<T, Ix1> {
             )
         };
         if res.is_null() {
-            Err(ErrorKind::dims_cast(self, dims))
+            Err(ErrorKind::py(self.py()))
         } else {
             Ok(())
         }
@@ -936,7 +936,7 @@ impl<T: TypeNum, D> PyArray<T, D> {
         let other_ptr = other.as_array_ptr();
         let result = unsafe { PY_ARRAY_API.PyArray_CopyInto(other_ptr, self_ptr) };
         if result == -1 {
-            Err(ErrorKind::dtype_cast(self, U::npy_data_type()))
+            Err(ErrorKind::py(self.py()))
         } else {
             Ok(())
         }
@@ -965,7 +965,7 @@ impl<T: TypeNum, D> PyArray<T, D> {
             )
         };
         if ptr.is_null() {
-            Err(ErrorKind::dtype_cast(self, U::npy_data_type()))
+            Err(ErrorKind::py(self.py()))
         } else {
             Ok(unsafe { PyArray::<U, D>::from_owned_ptr(self.py(), ptr) })
         }
@@ -1018,7 +1018,7 @@ impl<T: TypeNum, D> PyArray<T, D> {
             )
         };
         if ptr.is_null() {
-            Err(ErrorKind::dims_cast(self, dims))
+            Err(ErrorKind::py(self.py()))
         } else {
             Ok(unsafe { PyArray::<T, D2>::from_owned_ptr(self.py(), ptr) })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::array::{
     PyArrayDyn,
 };
 pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
-pub use crate::error::{ArrayShape, ErrorKind, IntoPyErr, IntoPyResult};
+pub use crate::error::{ErrorKind, IntoPyErr, IntoPyResult};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};
 pub use crate::types::{c32, c64, NpyDataType, TypeNum};
 pub use ndarray::{Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};

--- a/tests/to_py.rs
+++ b/tests/to_py.rs
@@ -68,7 +68,6 @@ macro_rules! small_array_test {
 small_array_test!(i8 u8 i16 u16 i32 u32 i64 u64 usize);
 
 #[test]
-#[ignore]
 fn usize_dtype() {
     let gil = pyo3::Python::acquire_gil();
     let py = gil.python();


### PR DESCRIPTION
They must be handled manually.